### PR TITLE
Fix: App doesn't run with correct "working dir" on Mac OSX

### DIFF
--- a/native/src/launcher.cpp
+++ b/native/src/launcher.cpp
@@ -16,6 +16,9 @@
 
 #ifdef WINDOWS
 #include <windows.h>
+#include <direct.h>
+#else
+#include <unistd.h>
 #endif
 
 #include <launcher.h>
@@ -26,10 +29,6 @@
 #include <fstream>
 #include <picojson.h>
 #include <dlfcn.h>
-
-#ifdef MACOSX
-#include <unistd.h>
-#endif
 
 extern std::string getExecutableDir();
 extern int g_argc;
@@ -88,9 +87,14 @@ void* launchVM(void* params) {
 	PtrCreateJavaVM ptrCreateJavaVM = (PtrCreateJavaVM)GetProcAddress(hinstLib,"JNI_CreateJavaVM");
 #endif
     
-#ifdef MACOSX
-    chdir(execDir.c_str());
+#ifdef WINDOWS
+    int rval = _chdir(execDir.c_str());
+#else
+    int rval = chdir(execDir.c_str());
 #endif
+    if(rval != 0) {
+        printf("Couldn't change working directory to: %s\n", execDir.c_str());
+    }
 
     jint res = ptrCreateJavaVM(&jvm, (void**)&env, &args);
 


### PR DESCRIPTION
Possible fix to Issue #13. It's probably not the most sexy fix, but I didn't find any option to change the working directory via Info.plist, or with arguments passed to JNI_CreateJavaVM().
