### PR TITLE
Improve JRE minimizer robustness when deleting directories.

### DIFF
--- a/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/src/main/java/com/badlogicgames/packr/Packr.java
@@ -190,6 +190,7 @@ public class Packr {
 			FileUtils.deleteDirectory(new File(outDir, "jre/bin"));
 		}
 		for(String minimizedDir : config.minimizeJre) {
+			minimizedDir = minimizedDir.trim();
 			File file = new File(outDir, minimizedDir);
 			if(file.isDirectory()) FileUtils.deleteDirectory(new File(outDir, minimizedDir));
 			else file.delete();

--- a/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/src/main/java/com/badlogicgames/packr/Packr.java
@@ -192,8 +192,12 @@ public class Packr {
 		for(String minimizedDir : config.minimizeJre) {
 			minimizedDir = minimizedDir.trim();
 			File file = new File(outDir, minimizedDir);
-			if(file.isDirectory()) FileUtils.deleteDirectory(new File(outDir, minimizedDir));
-			else file.delete();
+			try {
+				if(file.isDirectory()) FileUtils.deleteDirectory(new File(outDir, minimizedDir));
+				else file.delete();
+			} catch (Exception e) {
+				System.out.println("Failed to delete file " + file.getPath() + ": " + e.getMessage());
+			}
 		}
 		new File(outDir, "jre/lib/rhino.jar").delete();
 		


### PR DESCRIPTION
I had two problems when trying to use packr:

1. Example minimize configuration files contained trailing whitespace. I didn't notice that at first and it led to packr crashing during minimization. I modified the minimization code to trim each entry in the config file.
2. Even if minimizer fails to delete something, it shouldn't just crash. It will now print error message but continue minimizing and will produce a working executable.