### PR TITLE
Fix for Mac OS X Java installation promt (#29)

### DIFF
--- a/native/src/launcher.cpp
+++ b/native/src/launcher.cpp
@@ -74,7 +74,7 @@ void* launchVM(void* params) {
 
 #ifndef WINDOWS
     #ifdef MACOSX
-        std::string jre = execDir + std::string("/jre/lib/server/libjvm.dylib");
+        std::string jre = execDir + std::string("/jre/lib/jli/libjli.dylib");
     #elif defined(__LP64__)
         std::string jre = execDir + std::string("/jre/lib/amd64/server/libjvm.so");
     #else


### PR DESCRIPTION
Fix for the problem #29. According to:
http://stackoverflow.com/questions/14105575/eclipse-on-mac-10-8-installed-1-7-0-jre-jdk-but-eclipse-wont-launch#comment38546699_21766432