### PR TITLE
Modify packer configs and launcher to use classpath instead of jar

### DIFF
--- a/native/src/launcher.cpp
+++ b/native/src/launcher.cpp
@@ -49,11 +49,24 @@ void* launchVM(void* params) {
         exit(EXIT_FAILURE);
     }
     
-    std::string jarFile = execDir + std::string("/") + json.get<picojson::object>()["jar"].to_str();
+    std::string jarFile = "";
+    picojson::array jarFiles = json.get<picojson::object>()["classpath"].get<picojson::array>();
+    for(unsigned i = 0; i < jarFiles.size(); i++) {
+        std::string jar = jarFiles[i].to_str().c_str();
+        jarFile = jarFile + execDir + std::string("/") + jar;
+        if (i + 1 < jarFiles.size()) {
+        	#ifdef WINDOWS
+        		jarFile += ";";
+        	#else
+        		jarFile += ":";
+        	#endif
+        }
+    }
+    
     std::string main = json.get<picojson::object>()["mainClass"].to_str();
     std::string classPath = std::string("-Djava.class.path=") + jarFile;
     picojson::array vmArgs = json.get<picojson::object>()["vmArgs"].get<picojson::array>();
-    printf("jar: %s\n", jarFile.c_str());
+    printf("classpath: %s\n", jarFile.c_str());
     printf("mainClass: %s\n", main.c_str());
     
     JavaVMOption* options = (JavaVMOption*)malloc(sizeof(JavaVMOption) * (1 + vmArgs.size()));


### PR DESCRIPTION
In cases due to licensing, size constraints, or a desire for a modular distribution model you might be restricted from packaging your entire application into one jar file.  Since the vmarg `-Djava.class.path=` was already being set by the launcher executable, you could not specify it again in the vmargs, as it would not override.  By switching appjar from a single string into an array of strings, and more aptly naming it classpath, the classpath vm arg can be set to multiple files if necessary.

As an example
``` 
{
    "platform": "linux64",
    "jdk": "jre/openjdk-1.7.0-u80-unofficial-linux-amd64-image.zip",
    "executable": "myapp",
    "classpath": ["myapp.jar", "myapp_steam.jar"],
    "mainclass": "com/my/app/MainClass",
    "vmargs": [
       "-Xmx1G"
    ],
    "resources": [
        "pom.xml",
        "src/main/resources"
    ],
    "minimizejre": "soft",
    "outdir": "output-linux/"
}
```

As I don't have a Windows or Mac build environment, natives will have to be rebuilt.  I know for certain the Linux one at least builds and does work.