### PR TITLE
Refactored Java code.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Mario Zechner, badlogic, contact at badlogicgames dot com
+Daniel Ludwig, code-disaster, codi at code-disaster dot com

--- a/README.md
+++ b/README.md
@@ -1,39 +1,47 @@
 # packr
 
-Packages your JAR, assets and a JVM for distribution on Windows, Linux and Mac OS X, adding a native executable file to make it appear like the app is a native app. Packr is most suitable for GUI applications, such as games made with [libGDX](http://libgdx.badlogicgames.com/).
+__Public Service Announcement: With packr v2.0, command line interfaces to both packr.jar and the native executable have changed, as well as the format of minimize profiles! If you upgrade from a previous version, please read this documentation again to make sure you've updated your configuration(s) accordingly.__
+
+## About
+
+Packages your JAR, assets and a JVM for distribution on Windows, Linux and Mac OS X, adding a native executable file to make it appear like a native app. Packr is most suitable for GUI applications, such as games made with [libGDX](http://libgdx.badlogicgames.com/).
 
 #### [Download Packr](http://bit.ly/packrgdx)
 
 ## Usage
 
-You point packr at your JAR file (containing all your code and assets), a JSON config file (specifying parameters to the JVM and the main class) and a URL or local file location to an OpenJDK build for the platform you want to build. Invoking packr from the command line may look like this:
+You point packr at your JAR file(s) containing your code and assets, some configuration parameters, and a URL or local file location to a JDK build for your target platform.
+
+Invoking packr from the command line may look like this:
 
 ```bash
 java -jar packr.jar \
-     -platform mac \
-     -jdk "openjdk-1.7.0-u45-unofficial-icedtea-2.4.3-macosx-x86_64-image.zip" \
-     -executable myapp \
-     -classpath myapp.jar \
-     -mainclass "com.my.app.MainClass" \
-     -vmargs "-Xmx1G" \
-     -resources src/main/resources;path/to/other/assets \
-     -minimizejre "soft" \
-     -outdir out
+     --platform mac \
+     --jdk openjdk-1.7.0-u45-unofficial-icedtea-2.4.3-macosx-x86_64-image.zip \
+     --executable myapp \
+     --classpath myapp.jar \
+     --mainclass com.my.app.MainClass \
+     --vmargs Xmx1G \
+     --resources src/main/resources path/to/other/assets \
+     --minimizejre soft \
+     --output out-mac
 ```
 
 | Parameter | Meaning |
 | --- | --- |
 | platform | one of "windows32", "windows64", "linux32", "linux64", "mac" |
-| jdk | ZIP file location or URL to an OpenJDK build containing a JRE. Prebuild JDKs can be found at https://github.com/alexkasko/openjdk-unofficial-builds |
+| jdk | ZIP file location or URL to an OpenJDK or Oracle JDK build containing a JRE. Prebuild OpenJDK packages can be found at https://github.com/alexkasko/openjdk-unofficial-builds |
 | executable | name of the native executable, without extension such as ".exe" |
-| icon (optional, OS X) | location of an AppBundle icon resource (.icns file) |
-| classpath | file locations of the JAR files to package, separated by `;` |
-| bundleidentifier (optional, OS X) | the bundle identifier of your Java application, e.g. "com.my.app" |
+| classpath | file locations of the JAR files to package |
 | mainclass | the fully qualified name of the main class, using dots to delimit package names |
-| vmargs | list of arguments for the JVM, separated by `;`, e.g. "-Xmx1G" |
-| outdir | output directory |
-| resources (optional) | list of files and directories to be packaged next to the native executable, separated by `;`.
-| minimizejre | minimize the JRE by removing directories and files as specified by the config file. Comes with two config files out of the box called "soft" and "hard". See below for details on the minimization config file. |
+| vmargs | list of arguments for the JVM, without leading dashes, e.g. "Xmx1G" |
+| resources (optional) | list of files and directories to be packaged next to the native executable |
+| minimizejre | minimize the JRE by removing directories and files as specified by an additional config file. Comes with a few config files out of the box. See below for details on the minimization config file. |
+| output | the output directory |
+| icon (optional, OS X) | location of an AppBundle icon resource (.icns file) |
+| bundleidentifier (optional, OS X) | the bundle identifier of your Java application, e.g. "com.my.app" |
+| verbose | prints more status information during processing, which can be useful for debugging |
+| help | shows the command line interface help |
 
 Alternatively, you can put all the command line arguments into a JSON file which might look like this:
 
@@ -47,14 +55,14 @@ Alternatively, you can put all the command line arguments into a JSON file which
     ],
     "mainclass": "com.my.app.MainClass",
     "vmargs": [
-       "-Xmx1G"
+       "Xmx1G"
     ],
     "resources": [
         "src/main/resources",
         "path/to/other/assets"
     ],
     "minimizejre": "soft",
-    "outdir": "out-mac"
+    "output": "out-mac"
 }
 ```
 
@@ -64,7 +72,15 @@ You can then invoke the tool like this:
 java -jar packr.jar my-packr-config.json
 ```
 
-Finally, you can use packr from within your code. Just add the JAR file to your project, either manually, or via the following Maven dependency:
+It is possible to combine a JSON configuration and the command line. For single options, the command line parameter overrides the equivalent JSON option. For multi-options (e.g. `classpath` or `vmargs`), the options are merged.
+
+This is an example which overrides the output folder and adds another VM argument. Note that the config file name is delimited by `--` because the option prior to it, `--vmargs`, allows multiple arguments:
+
+```bash
+java -jar packr.jar --output target/out-mac --vmargs Xms256m -- my-packr-config.json
+```
+
+Finally, you can use packr from within your Java code. Just add the JAR file to your project, either manually, or via the following Maven dependency:
 
 ```xml
 <dependency>
@@ -74,38 +90,84 @@ Finally, you can use packr from within your code. Just add the JAR file to your 
 </dependency>
 ```
 
-To invoke packr, you need to create an instance of `Config` and pass it to `Packr.pack()`
+To invoke packr, you need to create an instance of `PackrConfig` and pass it to `Packr.pack()`:
 
 ```java
-Config config = new Config();
-config.platform = Platform.windows;
+PackrConfig config = new PackrConfig();
+config.platform = PackrConfig.Platform.Windows32;
 config.jdk = "/User/badlogic/Downloads/openjdk-for-mac.zip";
 config.executable = "myapp";
 config.classpath = Arrays.asList("myjar.jar");
 config.mainClass = "com.my.app.MainClass";
-config.vmArgs = Arrays.asList("-Xmx1G");
-config.minimizeJre = new String[] { "jre/lib/rt/com/sun/corba", "jre/lib/rt/com/sun/jndi" };
+config.vmArgs = Arrays.asList("Xmx1G");
+config.minimizeJre = "soft";
 config.outDir = "out-mac";
 
-new Packr().pack(config)
+new Packr().pack(config);
 ```
 
 ## Minimization
 
-A standard JRE weighs about 90mb unpacked and about 50mb packed. Packr helps you cut down on that size, thus also reducing the download size of your app.
+### JRE
 
-To minimize the JRE that is bundled with your app, you have to specify a minimization configuration file via the `minimizejre` flag you supply to Packr. Such a minimization configuration contains the names of files and directories within the JRE to be removed, one per line in the file. E.g.:
+A standard OpenJDK JRE weighs about 90 mb unpacked. Packr helps you cut down on that size, thus also reducing the download size of your app.
 
+To minimize the JRE that is bundled with your app, you have to specify a minimization configuration file via the `minimizejre` flag you supply to Packr. A minimization configuration is a JSON file containing paths to files and directories within the JRE to be removed.
+
+As an example, have a look at the `soft` profile configuration:
+
+```json
+{
+  "reduce": [
+    {
+      "archive": "jre/lib/rt.jar",
+      "paths": [
+        "com/sun/corba",
+        "com/sun/jndi",
+        "com/sun/media",
+        "com/sun/naming",
+        "com/sun/rowset",
+        "sun/applet",
+        "sun/corba",
+        "sun/management"
+      ]
+    }
+  ],
+  "remove": [
+    {
+      "platform": "*",
+      "paths": [
+        "jre/lib/rhino.jar"
+      ]
+    },
+    {
+      "platform": "windows",
+      "paths": [
+        "jre/bin/*.exe",
+        "jre/bin/client"
+      ]
+    }
+  ]
+}
 ```
-jre/lib/rhino.jar
-jre/lib/rt/com/sun/corba
-```
 
-This will remove the rhino.jar (about 1.1MB) and all the packages and classes in com.sun.corba from the rt.jar file. To specify files and packages to be removed from the JRE, simply prepend them with `jre/lib/rt/`.
+This configuration will unpack `rt.jar`, remove all the listed packages and classes in `com.sun.*` and `sun.*`, then repack `rt.jar` again. By default, the JRE uses zero-compression on its JAR files to make application startup a little faster, so this step will reduce the size of `rt.jar` substantially.
 
-Packr comes with two such configurations out of the box, [`soft`](https://github.com/libgdx/packr/blob/master/src/main/resources/minimize/soft) and [`hard`](https://github.com/libgdx/packr/blob/master/src/main/resources/minimize/hard)
+Then, rhino.jar (about 1.1MB) and, in case of a Windows JRE, all executable files in `jre/bin/` and the folder `jre/bin/client/` will be removed.
 
-Additionally, Packr will compress the rt.jar file. By default, the JRE uses zero-compression on the rt.jar file to make application startup a little faster.
+Packr comes with two such configurations out of the box, [`soft`](https://github.com/libgdx/packr/blob/master/src/main/resources/minimize/soft) and [`hard`](https://github.com/libgdx/packr/blob/master/src/main/resources/minimize/hard). The `hard` profile removes a few more files, and repacks some additional JAR files.
+
+There's also a new, *experimental* configuration, [`oraclejre8`](https://github.com/libgdx/packr/blob/master/src/main/resources/minimize/oraclejre8), which reduces size of an Oracle 8 JRE following Oracle's redistribution rules described [here](http://www.oracle.com/technetwork/java/javase/jre-8-readme-2095710.html). It also repacks JAR files, reducing (unpacked) JRE size from about 180 mb to 70 mb. **This version is pretty much untested, so please use with care!**
+
+### Classpath
+
+Minimization aside, packr also removes all dynamic libraries which do not match the target platform from your project JAR file(s):
+
+| platform | files removed |
+| --- | --- |
+| Windows | `*.dylib`, `*.so` |
+| Linux | `*.dll`, `*.dylib` |
+| MacOS | `*.dll`, `*.so` |
 
 ## Output
 
@@ -144,19 +206,19 @@ outdir/
          icons.icns [if config.icon is set]
 ```
 
-You can further modify the Info.plist to your liking, e.g. add icons, a bundle identifier etc. If your `outdir` has the `.app` extension it will be treated as an application bundle by Mac OS X.
+You can further modify the Info.plist to your liking, e.g. add icons, a bundle identifier etc. If your `output` folder has the `.app` extension it will be treated as an application bundle by Mac OS X.
 
 ## Executable command line interface
 
 By default, the native executables forward any command line parameters to your Java application's main() function. So, with the configurations above, `./myapp -x y.z` is passed as `com.my.app.MainClass.main(new String[] {"-x", "y.z" })`.
 
-The executables themselves expose an own interface, which has to be explicitly enabled by passing `-c` or `--cli` as the **very first** parameter. In this case, a special delimiter parameter `--` is used to separate the native CLI from parameters to be passed to Java. In this case, the example above would be equal to `./myapp -c [arguments] -- -x y.z`.
+The executables themselves expose an own interface, which has to be enabled explicitly by passing `-c` or `--cli` as the **very first** parameter. In this case, the special delimiter parameter `--` is used to separate the native CLI from parameters to be passed to Java. In this case, the example above would be equal to `./myapp -c [arguments] -- -x y.z`.
 
 Try `./myapp -c --help` for a list of available options. They are also listed [here](https://github.com/libgdx/packr/blob/master/src/main/native/README.md#command-line-interface).
 
-> Note: On Windows, the executable does not show any output by default. Here you can use `myapp.exe -c --console --help` to spawn a console window, making terminal output visible.
+> Note: On Windows, the executable does not show any output by default. Here you can use `myapp.exe -c --console [arguments]` to spawn a console window, making terminal output visible.
 
-## Building
+## Building from source code
 
 If you want to modify the Java code only, it's sufficient to invoke Maven.
 
@@ -173,7 +235,7 @@ If you want to compile the native executables, please follow [these instructions
   * Icons aren't set yet on Windows and Linux, you need to do that manually.
   * Minimum platform requirement on MacOS is OS X 10.7.
   * JRE minimization is very conservative. Depending on your app, you can carve out stuff from a JRE yourself, disable minimization and pass your custom JRE to packr.
-  * On MacOS, the JVM is spawned in its own thread by default, which is a requirement of AWT. This does not work with code based on LWJGL3/GLFW, which needs the JVM be spawned on the main thread. You can enforce the latter with the `-XstartOnFirstThread` VM argument in your packr config.
+  * On MacOS, the JVM is spawned in its own thread by default, which is a requirement of AWT. This does not work with code based on LWJGL3/GLFW, which needs the JVM be spawned on the main thread. You can enforce the latter with adding the `-XstartOnFirstThread` VM argument to your MacOS packr config.
 
 ## License & Contributions
 

--- a/example-config-linux.json
+++ b/example-config-linux.json
@@ -7,12 +7,12 @@
     ],
     "mainclass": "com.badlogicgames.packr.TestApp",
     "vmargs": [
-    	"-Xmx1G"
+    	"Xmx1G"
     ],
     "resources": [
         "pom.xml",
         "src/main/resources"
     ],
     "minimizejre": "soft",
-    "outdir": "out-lin"
+    "output": "out-lin"
 }

--- a/example-config-mac.json
+++ b/example-config-mac.json
@@ -7,12 +7,12 @@
     ],
     "mainclass": "com.badlogicgames.packr.TestApp",
     "vmargs": [
-    	"-Xmx1G"
+    	"Xmx1G"
     ],
     "resources": [
         "pom.xml",
         "src/main/resources"
     ],
     "minimizejre": "soft",
-    "outdir": "out-mac"
+    "output": "out-mac"
 }

--- a/example-config-windows.json
+++ b/example-config-windows.json
@@ -7,12 +7,12 @@
     ],
     "mainclass": "com.badlogicgames.packr.TestApp",
     "vmargs": [
-    	"-Xmx1G"
+    	"Xmx1G"
     ],
     "resources": [
         "pom.xml",
         "src/main/resources"
     ],
     "minimizejre": "soft",
-    "outdir": "out-win"
+    "output": "out-win"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -111,5 +111,10 @@
 			<artifactId>minimal-json</artifactId>
 			<version>0.9.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.lexicalscope.jewelcli</groupId>
+			<artifactId>jewelcli</artifactId>
+			<version>0.8.9</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/src/main/java/com/badlogicgames/packr/Packr.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2014 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,427 +16,298 @@
 
 package com.badlogicgames.packr;
 
+import com.lexicalscope.jewel.cli.ArgumentValidationException;
+import com.lexicalscope.jewel.cli.CliFactory;
+import com.lexicalscope.jewel.cli.ValidationFailure;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.zeroturnaround.zip.ZipUtil;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.filefilter.TrueFileFilter;
-import org.zeroturnaround.zip.ZipUtil;
-
-import com.eclipsesource.json.JsonArray;
-import com.eclipsesource.json.JsonObject;
-import com.eclipsesource.json.JsonValue;
 
 /**
- * Takes a couple of parameters and a JRE and bundles them into a platform specific 
+ * Takes a couple of parameters and a JRE and bundles them into a platform specific
  * distributable (zip on Windows and Linux, app bundle on Mac OS X).
  * @author badlogic
  *
  */
 public class Packr {
-	public enum Platform {
-		windows32,
-		windows64,
-		linux32,
-		linux64,
-		mac
-	}
-	
-	public static class Config {
-		public Platform platform;
-		public String jdk;
-		public String executable;
-		public List<String> classpath = new ArrayList<String>();
-		public String mainClass;
-		public List<String> vmArgs = new ArrayList<String>();
-		public String[] minimizeJre;
-		public List<String> resources = new ArrayList<String>();
-		public String outDir;
-		public String iconResource;
-		public String bundleIdentifier = "com.yourcompany.identifier";
-	}
-	
-	public void pack(Config config) throws IOException {
-		// create output dir
-		File out = new File(config.outDir);
-		File target = out;
-		if(out.exists()) {
-			if(new File(".").equals(out)) {
-				System.out.println("Output directory equals working directory, aborting");
-				System.exit(-1);
-			}
-			if(new File("/").equals(out)) {
-				System.out.println("Output directory equals root, aborting");
-				System.exit(-1);
-			}
-			
-			System.out.println("Output directory '" + out.getAbsolutePath() + "' exists, deleting");
-			FileUtils.deleteDirectory(out);
-		}
-		out.mkdirs();
-		
-		Map<String, String> values = new HashMap<String, String>();
-		values.put("${executable}", config.executable);
-		values.put("${bundleIdentifier}", config.bundleIdentifier);
 
-		// if this is a mac build, let's create the app bundle structure
-		if(config.platform == Platform.mac) {
-			new File(out, "Contents").mkdirs();
-			FileUtils.writeStringToFile(new File(out, "Contents/Info.plist"), readResourceAsString("/Info.plist", values));
-			target = new File(out, "Contents/MacOS");
-			target.mkdirs();
-			File resources = new File(out, "Contents/Resources");
-			resources.mkdirs();
-			if(config.iconResource != null) {
-				// copy icon to Contents/Resources/icons.icns
-				File icons = new File(config.iconResource);
-				if(icons.exists()) {
-					FileUtils.copyFile(new File(config.iconResource), new File(resources, "icons.icns"));
-				}
+	private PackrConfig config;
+
+	public void pack(PackrConfig config) throws IOException {
+
+		config.validate();
+		this.config = config;
+
+		File output = config.outDir;
+
+		cleanOrCreateOutputFolder(output);
+
+		output = buildMacBundle(output);
+
+		copyExecutableAndClasspath(output);
+
+		writeConfig(output);
+
+		copyJRE(output);
+
+		copyResources(output);
+
+		PackrReduce.minimizeJre(output, config);
+
+		PackrReduce.removePlatformLibs(output, config);
+
+		System.out.println("Done!");
+	}
+
+	private void cleanOrCreateOutputFolder(File output) throws IOException {
+		if (output.exists()) {
+			System.out.println("Cleaning output directory '" + output.getAbsolutePath() + "' ...");
+			FileUtils.deleteDirectory(output);
+		} else {
+			PackrFileUtils.mkdirs(output);
+		}
+	}
+
+	private File buildMacBundle(File output) throws IOException {
+
+		if (config.platform != PackrConfig.Platform.MacOS) {
+			return output;
+		}
+
+		// replacement strings for Info.plist
+		Map<String, String> values = new HashMap<String, String>();
+
+		values.put("${executable}", config.executable);
+
+		if (config.bundleIdentifier != null) {
+			values.put("${bundleIdentifier}", config.bundleIdentifier);
+		} else {
+			values.put("${bundleIdentifier}", config.mainClass.substring(0, config.mainClass.lastIndexOf('.')));
+		}
+
+		// create folder structure
+
+		PackrFileUtils.mkdirs(new File(output, "Contents"));
+		FileUtils.writeStringToFile(new File(output, "Contents/Info.plist"), readResourceAsString("/Info.plist", values));
+
+		File target = new File(output, "Contents/MacOS");
+		PackrFileUtils.mkdirs(target);
+
+		File resources = new File(output, "Contents/Resources");
+		PackrFileUtils.mkdirs(resources);
+
+		if (config.iconResource != null) {
+			// copy icon to Contents/Resources/icons.icns
+			if (config.iconResource.exists()) {
+				FileUtils.copyFile(config.iconResource, new File(resources, "icons.icns"));
 			}
 		}
-		
-		// write jar, exe and config to target folder
+
+		return target;
+	}
+
+	private void copyExecutableAndClasspath(File output) throws IOException {
 		byte[] exe = null;
 		String extension = "";
-		switch(config.platform) {
-			case windows32:
+
+		switch (config.platform) {
+			case Windows32:
 				exe = readResource("/packr-windows.exe");
 				extension = ".exe";
 				break;
-			case windows64:
+			case Windows64:
 				exe = readResource("/packr-windows-x64.exe");
 				extension = ".exe";
 				break;
-			case linux32:
+			case Linux32:
 				exe = readResource("/packr-linux");
 				break;
-			case linux64:
+			case Linux64:
 				exe = readResource("/packr-linux-x64");
 				break;
-			case mac:
+			case MacOS:
 				exe = readResource("/packr-mac");
 				break;
 		}
-		FileUtils.writeByteArrayToFile(new File(target, config.executable + extension), exe);
-		new File(target, config.executable + extension).setExecutable(true);
+
+		System.out.println("Copying executable ...");
+		FileUtils.writeByteArrayToFile(new File(output, config.executable + extension), exe);
+		PackrFileUtils.chmodX(new File(output, config.executable + extension));
+
+		System.out.println("Copying classpath(s) ...");
 		for (String file : config.classpath) {
-			FileUtils.copyFile(new File(file), new File(target, new File(file).getName()));
+			File cpSrc = new File(file);
+			File cpDst = new File(output, new File(file).getName());
+
+			if (cpSrc.isFile()) {
+				FileUtils.copyFile(cpSrc, cpDst);
+			} else if (cpSrc.isDirectory()) {
+				FileUtils.copyDirectory(cpSrc, cpDst);
+			} else {
+				System.err.println("Warning! Classpath not found: " + cpSrc);
+			}
 		}
-		writeConfig(config, new File(target, "config.json"));
-		
-		// add JRE from local or remote zip file
-		File jdkFile = null;		
-		if(config.jdk.startsWith("http://") || config.jdk.startsWith("https://")) {
-			System.out.println("Downloading JDK from '" + config.jdk + "'");
-			jdkFile = new File(target, "jdk.zip");
-			InputStream in = new URL(config.jdk).openStream();
-			OutputStream outJdk = FileUtils.openOutputStream(jdkFile);
-			IOUtils.copy(in, outJdk);
-			in.close();
-			outJdk.close();
-		} else {
-			jdkFile = new File(config.jdk);			
-		}
-		File tmp = new File(target, "tmp");
-		tmp.mkdirs();
-		System.out.println("Unpacking JRE");
-		ZipUtil.unpack(jdkFile, tmp);
-		File jre = searchJre(tmp);
-		if(jre == null) {
-			System.out.println("Couldn't find JRE in JDK, see '" + tmp.getAbsolutePath() + "'");
-			System.exit(-1);
-		}
-		FileUtils.copyDirectory(jre, new File(target, "jre"));
-		FileUtils.deleteDirectory(tmp);
-		if(config.jdk.startsWith("http://") || config.jdk.startsWith("https://")) {
-			jdkFile.delete();
-		}
-		
-		// copy resources
-		System.out.println("copying resources");
-		copyResources(target, config.resources);
-		
-		// perform tree shaking		
-		if(config.minimizeJre != null) {	
-			minimizeJre(config, target);			
-		}
-		
-		System.out.println("Done!");
 	}
-	
-	private void writeConfig(Config config, File file) throws IOException {
+
+	private void writeConfig(File output) throws IOException {
+
 		StringBuilder builder = new StringBuilder();
 		builder.append("{\n");
 		builder.append("  \"classPath\": [");
-		
-		{
-			String delim = "\n";
-			for (String f : config.classpath) {
-				builder.append(delim).append("    \"" + new File(f).getName() + "\"");
-				delim = ",\n";
-			}
-			builder.append("\n  ],\n");
+
+		String delim = "\n";
+		for (String f : config.classpath) {
+			builder.append(delim).append("    \"").append(new File(f).getName()).append("\"");
+			delim = ",\n";
 		}
-		
-		builder.append("  \"mainClass\": \"" + config.mainClass + "\",\n");
+		builder.append("\n  ],\n");
+
+		builder.append("  \"mainClass\": \"").append(config.mainClass).append("\",\n");
 		builder.append("  \"vmArgs\": [\n");
-		for(int i = 0; i < config.vmArgs.size(); i++) {
+
+		for (int i = 0; i < config.vmArgs.size(); i++) {
 			String vmArg = config.vmArgs.get(i);
-			builder.append("    \"" + vmArg + "\"");
-			if(i < config.vmArgs.size() - 1) {
+			builder.append("    \"");
+			if (!vmArg.startsWith("-")) {
+				builder.append("-");
+			}
+			builder.append(vmArg).append("\"");
+			if (i < config.vmArgs.size() - 1) {
 				builder.append(",");
 			}
 			builder.append("\n");
 		}
 		builder.append("  ]\n");
 		builder.append("}");
-		FileUtils.writeStringToFile(file, builder.toString());
+
+		FileUtils.writeStringToFile(new File(output, "config.json"), builder.toString());
 	}
 
-	private void minimizeJre(Config config, File outDir) throws IOException {
-		// remove stuff from the JRE
-		System.out.println("minimizing JRE");
-		System.out.println("unpacking rt.jar");
-		ZipUtil.unpack(new File(outDir, "jre/lib/rt.jar"), new File(outDir, "jre/lib/rt"));
-		
-		if(config.platform == Platform.windows32 || config.platform == Platform.windows64) {
-			FileUtils.deleteDirectory(new File(outDir, "jre/bin/client"));
-			for(File file: new File(outDir, "jre/bin").listFiles()) {
-				if(file.getName().endsWith(".exe")) file.delete();
-			}
+	private void copyJRE(File output) throws IOException {
+
+		File jdkFile;
+		boolean fetchFromRemote = config.jdk.startsWith("http://") || config.jdk.startsWith("https://");
+
+		// add JRE from local or remote zip file
+		if (fetchFromRemote) {
+			System.out.println("Downloading JDK from '" + config.jdk + "' ...");
+			jdkFile = new File(output, "jdk.zip");
+			InputStream in = new URL(config.jdk).openStream();
+			OutputStream outJdk = FileUtils.openOutputStream(jdkFile);
+			IOUtils.copy(in, outJdk);
+			in.close();
+			outJdk.close();
 		} else {
-			FileUtils.deleteDirectory(new File(outDir, "jre/bin"));
+			jdkFile = new File(config.jdk);
 		}
-		for(String minimizedDir : config.minimizeJre) {
-			minimizedDir = minimizedDir.trim();
-			File file = new File(outDir, minimizedDir);
-			try {
-				if(file.isDirectory()) FileUtils.deleteDirectory(new File(outDir, minimizedDir));
-				else file.delete();
-			} catch (Exception e) {
-				System.out.println("Failed to delete file " + file.getPath() + ": " + e.getMessage());
-			}
+
+		System.out.println("Unpacking JRE ...");
+		File tmp = new File(output, "tmp");
+		PackrFileUtils.mkdirs(tmp);
+		ZipUtil.unpack(jdkFile, tmp);
+
+		File jre = searchJre(tmp);
+		if (jre == null) {
+			throw new IOException("Couldn't find JRE in JDK, see '" + tmp.getAbsolutePath() + "'");
 		}
-		new File(outDir, "jre/lib/rhino.jar").delete();
-		
-		System.out.println("packing rt.jar");
-		new File(outDir, "jre/lib/rt.jar").delete();
-		ZipUtil.pack(new File(outDir, "jre/lib/rt"), new File(outDir, "jre/lib/rt.jar"));
-		FileUtils.deleteDirectory(new File(outDir, "jre/lib/rt"));
-		
-		// let's remove any shared libs not used on the platform, e.g. libgdx/lwjgl natives
-		for (String classpath : config.classpath) {
-			File jar = new File(outDir, new File(classpath).getName());
-			File jarDir = new File(outDir, jar.getName()+ ".tmp");
-			ZipUtil.unpack(jar, jarDir);
-		
-			Set<String> extensions = new HashSet<String>();
-			if(config.platform != Platform.linux32 && config.platform != Platform.linux64) { extensions.add(".so"); }
-			if(config.platform != Platform.windows32 && config.platform != Platform.windows64) { extensions.add(".dll"); }
-			if(config.platform != Platform.mac) { extensions.add(".dylib"); }
-			
-			for(Object obj: FileUtils.listFiles(jarDir, TrueFileFilter.INSTANCE , TrueFileFilter.INSTANCE )) {
-				File file = new File(obj.toString());
-				for(String extension: extensions) {
-					if(file.getName().endsWith(extension)) file.delete();
-				}
-			}
-			
-			jar.delete();
-			ZipUtil.pack(jarDir, jar);
-			FileUtils.deleteDirectory(jarDir);
+
+		FileUtils.copyDirectory(jre, new File(output, "jre"));
+		FileUtils.deleteDirectory(tmp);
+
+		if (fetchFromRemote) {
+			PackrFileUtils.delete(jdkFile);
 		}
 	}
 
-	private void copyResources(File targetDir, List<String> resources) throws IOException {
-		for(String resource: resources) {
-			File file = new File(resource);
-			if(!file.exists()) {
-				System.out.println("resource '" + file.getAbsolutePath() + "' doesn't exist");
-				System.exit(-1);
-			}
-			if(file.isFile()) {
-				FileUtils.copyFile(file, new File(targetDir, file.getName()));
-			}
-			if(file.isDirectory()) {
-				File target = new File(targetDir, file.getName());
-				target.mkdirs();
-				FileUtils.copyDirectory(file, target);
-			}
-		}
-	}
-	
 	private File searchJre(File tmp) {
-		if(tmp.getName().equals("jre") && tmp.isDirectory() && (new File(tmp, "bin/java").exists() || new File(tmp, "bin/java.exe").exists())) {
+		if (tmp.getName().equals("jre") && tmp.isDirectory()
+				&& (new File(tmp, "bin/java").exists() || new File(tmp, "bin/java.exe").exists())) {
 			return tmp;
-		} else {
-			for(File child: tmp.listFiles()) {
-				if(child.isDirectory()) {
+		}
+
+		File[] childs = tmp.listFiles();
+		if (childs != null) {
+			for (File child : childs) {
+				if (child.isDirectory()) {
 					File found = searchJre(child);
-					if(found != null) return found;
+					if (found != null) {
+						return found;
+					}
 				}
 			}
-			return null;
+		}
+
+		return null;
+	}
+
+	private void copyResources(File output) throws IOException {
+		if (config.resources != null) {
+			System.out.println("Copying resources ...");
+
+			for (File file : config.resources) {
+				if (!file.exists()) {
+					throw new IOException("Resource '" + file.getAbsolutePath() + "' doesn't exist");
+				}
+
+				if (file.isFile()) {
+					FileUtils.copyFile(file, new File(output, file.getName()));
+				}
+
+				if (file.isDirectory()) {
+					File target = new File(output, file.getName());
+					PackrFileUtils.mkdirs(target);
+					FileUtils.copyDirectory(file, target);
+				}
+			}
 		}
 	}
 
 	private byte[] readResource(String resource) throws IOException {
 		return IOUtils.toByteArray(Packr.class.getResourceAsStream(resource));
 	}
-	
+
 	private String readResourceAsString(String resource, Map<String, String> values) throws IOException {
 		String txt = IOUtils.toString(Packr.class.getResourceAsStream(resource), "UTF-8");
 		return replace(txt, values);
 	}
-	
-	private String replace (String txt, Map<String, String> values) {
+
+	private String replace(String txt, Map<String, String> values) {
 		for (String key : values.keySet()) {
 			String value = values.get(key);
 			txt = txt.replace(key, value);
 		}
 		return txt;
 	}
-	
-	public static void main(String[] args) throws IOException {
-		if(args.length > 1) {
-			Map<String, String> arguments = parseArgs(args);
-			Config config = new Config();
-			config.platform = Platform.valueOf(arguments.get("platform"));
-			config.jdk = arguments.get("jdk");
-			config.executable = arguments.get("executable");
-			config.classpath =  Arrays.asList(arguments.get("classpath").split(";"));
-			config.iconResource = arguments.get("icon");
-			config.mainClass = arguments.get("mainclass");
-			if(arguments.get("bundleidentifier") != null) {
-				config.bundleIdentifier = arguments.get("bundleidentifier");
-			}
-			if(arguments.get("vmargs") != null) {
-				config.vmArgs = Arrays.asList(arguments.get("vmargs").split(";"));
-			}
-			config.outDir = arguments.get("outdir");
-			if(arguments.get("minimizejre") != null) {
-				if(new File(arguments.get("minimizejre")).exists()) {
-					config.minimizeJre = FileUtils.readFileToString(new File(arguments.get("minimizejre"))).split("\r?\n");
-				} else {
-					InputStream in = Packr.class.getResourceAsStream("/minimize/" + arguments.get("minimizejre"));
-					if(in != null) {
-						config.minimizeJre = IOUtils.toString(in).split("\r?\n");
-						in.close();
-					} else {
-						config.minimizeJre = new String[0];
-					}
-				}
-			}
-			if(arguments.get("resources") != null) config.resources = Arrays.asList(arguments.get("resources").split(";"));
-			new Packr().pack(config);
-		} else {
-			if(args.length == 0) {
-				printHelp();
-			} else {
-				JsonObject json = JsonObject.readFrom(FileUtils.readFileToString(new File(args[0])));
-				Config config = new Config();
-				config.platform = Platform.valueOf(json.get("platform").asString());
-				config.jdk = json.get("jdk").asString();
-				config.executable = json.get("executable").asString();
-				config.classpath = toStringArray(json.get("classpath").asArray());
-				if(json.get("icon") != null) {
-					config.iconResource = json.get("icon").asString();
-				}
-				config.mainClass = json.get("mainclass").asString();
-				if(json.get("bundleidentifier") != null) {
-					config.bundleIdentifier = json.get("bundleidentifier").asString();
-				}
-				if(json.get("vmargs") != null) {
-					config.vmArgs = toStringArray(json.get("vmargs").asArray());
-				}
-				config.outDir = json.get("outdir").asString();
-				if(json.get("minimizejre") != null) {
-					if(new File(json.get("minimizejre").asString()).exists()) {
-						config.minimizeJre = FileUtils.readFileToString(new File(json.get("minimizejre").asString())).split("\r?\n");
-					} else {
-						InputStream in = Packr.class.getResourceAsStream("/minimize/" + json.get("minimizejre"));
-						if(in != null) {
-							config.minimizeJre = IOUtils.toString(in).split("\r?\n");
-							in.close();
-						} else {
-							config.minimizeJre = new String[0];
-						}
-					}
-				}
-				if(json.get("resources") != null) {
-					config.resources = toStringArray(json.get("resources").asArray());
-				}
-				new Packr().pack(config);
-			}
-		}
-	}
-	
-	private static List<String> toStringArray(JsonArray array) {
-		List<String> result = new ArrayList<String>();
-		for(JsonValue value: array) {
-			result.add(value.asString());
-		}
-		return result;
-	}
-	
-	private static void error() {
-		printHelp();
-		System.exit(-1);
-	}
-	
-	private static void printHelp() {
-		System.out.println("Usage: packr <args>");
-		System.out.println("-platform <windows32|windows64|linux32|linux64|mac>");
-		System.out.println("                                     ... operating system to pack for");
-		System.out.println("-jdk <path-or-url>                   ... path to a JDK to be bundled (needs to fit platform)");
-		System.out.println("                                         Can be a ZIP file or URL to a ZIP file");
-		System.out.println("-executable <name>                   ... name of the executable, e.g. 'mygame', without extension");
-		System.out.println("-classpath <file.jar>                ... JAR file containing code and assets to be packed");
-		System.out.println("                                         Can contain multiple JAR files, separated by ;");
-		System.out.println("-icon <file>                         ... file containing icon resources (needs to fit platform)");
-		System.out.println("                                         Only supported on OS X (.icns)");
-		System.out.println("-mainclass <main-class>              ... fully qualified main class name, e.g. com/badlogic/MyApp");
-		System.out.println("-bundleidentifier <identifier>       ... bundle identifier, e.g. com.badlogic");
-		System.out.println("                                         Only used for Info.plist on OS X");
-		System.out.println("-vmargs <args>                       ... arguments passed to the JVM, e.g. -Xmx1G, separated by ;");
-		System.out.println("-minimizejre <configfile>            ... minimize the JRE by removing folders and files specified in the config file");
-		System.out.println("                                         three config files come with packr: 'soft' and 'hard' which may or may not break your app");
-		System.out.println("-resources <files-and-folders>       ... additional files and folders to be packed next to the");
-		System.out.println("                                         executable. Entries are separated by a ;");
-		System.out.println("-outdir <dir>                        ... output directory");
-	}
-	
-	private static Map<String, String> parseArgs (String[] args) {
-		if (args.length < 12) {
-			error();
-		}
 
-		Map<String, String> params = new HashMap<String, String>();
-		for (int i = 0; i < args.length; i += 2) {
-			String param = args[i].replace("-", "");
-			String value = args[i + 1];
-			params.put(param, value);
+	public static void main(String[] args) {
+
+		try {
+
+			PackrCommandLine commandLine = CliFactory.parseArguments(PackrCommandLine.class, args);
+
+			if (commandLine.help()) {
+				return;
+			}
+
+			new Packr().pack(new PackrConfig(commandLine));
+
+		} catch (ArgumentValidationException e) {
+			for (ValidationFailure failure : e.getValidationFailures()) {
+				System.err.println(failure.getMessage());
+			}
+			System.exit(-1);
+		} catch (IOException e) {
+			e.printStackTrace();
+			System.exit(-1);
 		}
-		
-		if(params.get("platform") == null) error();
-		if(params.get("jdk") == null) error();
-		if(params.get("executable") == null) error();
-		if(params.get("classpath") == null) error();
-		if(params.get("mainclass") == null) error();
-		if(params.get("outdir") == null) error();
-		
-		return params;
 	}
+
 }

--- a/src/main/java/com/badlogicgames/packr/PackrCommandLine.java
+++ b/src/main/java/com/badlogicgames/packr/PackrCommandLine.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogicgames.packr;
+
+import com.lexicalscope.jewel.cli.Option;
+import com.lexicalscope.jewel.cli.Unparsed;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Packr command line interface.
+ *
+ * Use 'java -jar packr[-X.Y-SNAPSHOT].jar --help' to show this command line help.
+ */
+public interface PackrCommandLine {
+
+	@Option(helpRequest = true, description = "display help", shortName = "h", longName = "help")
+	boolean help();
+
+	@Option(description = "print additional information to console", shortName = "v", longName = "verbose")
+	boolean verbose();
+
+	@Unparsed
+	File config();
+
+	boolean isConfig();
+
+	@Option(description = "target operating system", longName = "platform", defaultToNull = true)
+	String platform();
+
+	@Option(description = "file path or URL to a JDK to be bundled", longName = "jdk", defaultToNull = true)
+	String jdk();
+
+	@Option(description = "name of native executable, without extension", longName = "executable", defaultToNull = true)
+	String executable();
+
+	@Option(description = "JAR file(s) containing code and assets to be packed", longName = "classpath", defaultToNull = true)
+	List<String> classpath();
+
+	@Option(description = "fully qualified main class name, e.g. com.badlogic.MyApp", longName = "mainclass", defaultToNull = true)
+	String mainClass();
+
+	@Option(description = "arguments passed to the JVM, e.g. Xmx1G, without dashes", longName = "vmargs", defaultToNull = true)
+	List<String> vmArgs();
+
+	@Option(description = "minimize JRE by removing folders and files specified in config file", longName = "minimizejre", defaultToNull = true)
+	String minimizeJre();
+
+	@Option(description = "additional files and folders to be packed next to the executable", longName = "resources", defaultToNull = true)
+	List<File> resources();
+
+	@Option(description = "output directory", longName = "output", defaultToNull = true)
+	File outDir();
+
+	@Option(description = "file containing icon resources (needs to fit platform, OS X only)", longName = "icon", defaultToNull = true)
+	File iconResource();
+
+	@Option(description = "bundle identifier, e.g. com.badlogic (used for Info.plist on OS X)", longName = "bundle", defaultToNull = true)
+	String bundleIdentifier();
+
+}

--- a/src/main/java/com/badlogicgames/packr/PackrConfig.java
+++ b/src/main/java/com/badlogicgames/packr/PackrConfig.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogicgames.packr;
+
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The Packr configuration can be read from command line, read from a JSON config file, or
+ * created from Java code directly.
+ *
+ * Command line parameters can be used to override (single-argument parameters) or extend
+ * (multi-argument parameters) JSON settings.
+ */
+public class PackrConfig {
+
+	public enum Platform {
+		Windows32("windows32"),
+		Windows64("windows64"),
+		Linux32("linux32"),
+		Linux64("linux64"),
+		MacOS("mac");
+
+		final String desc;
+
+		Platform(String desc) {
+			this.desc = desc;
+		}
+
+		static Platform byDesc(String desc) throws IOException {
+			for (Platform value : values()) {
+				if (value.desc.equalsIgnoreCase(desc)) {
+					return value;
+				}
+			}
+			throw new IOException("Invalid platform '" + desc + "'");
+		}
+	}
+
+	public Platform platform;
+	public String jdk;
+	public String executable;
+	public List<String> classpath;
+	public String mainClass;
+	public List<String> vmArgs;
+	public String minimizeJre;
+	public List<File> resources;
+	public File outDir;
+	public File iconResource;
+	public String bundleIdentifier;
+
+	public boolean verbose;
+
+	public PackrConfig() {
+
+	}
+
+	public PackrConfig(Platform platform, String jdk, String executable,
+					   List<String> classpath, String mainClass, File outDir) throws IOException {
+
+		this.platform = platform;
+		this.jdk = jdk;
+		this.executable = executable;
+		this.classpath = classpath;
+		this.mainClass = mainClass;
+		this.outDir = outDir;
+	}
+
+	public PackrConfig(PackrCommandLine commandLine) throws IOException {
+
+		verbose = commandLine.verbose();
+
+		// parse config file, if one is given
+
+		if (commandLine.isConfig()) {
+			readConfigJson(commandLine.config());
+		}
+
+		// evaluate optional command line parameters
+		// if given, they override the config file settings
+
+		if (commandLine.platform() != null) {
+			platform = Platform.byDesc(commandLine.platform());
+		}
+
+		if (commandLine.jdk() != null) {
+			jdk = commandLine.jdk();
+		}
+
+		if (commandLine.executable() != null) {
+			executable = commandLine.executable();
+		}
+
+		if (commandLine.classpath() != null) {
+			classpath = appendTo(classpath, commandLine.classpath());
+		}
+
+		if (commandLine.mainClass() != null) {
+			mainClass = commandLine.mainClass();
+		}
+
+		if (commandLine.vmArgs() != null) {
+			vmArgs = appendTo(vmArgs, commandLine.vmArgs());
+		}
+
+		if (commandLine.minimizeJre() != null) {
+			minimizeJre = commandLine.minimizeJre();
+		}
+
+		if (commandLine.resources() != null) {
+			resources = appendTo(resources, commandLine.resources());
+		}
+
+		if (commandLine.outDir() != null) {
+			outDir = commandLine.outDir();
+		}
+
+		if (commandLine.iconResource() != null) {
+			iconResource = commandLine.iconResource();
+		}
+
+		if (commandLine.bundleIdentifier() != null) {
+			bundleIdentifier = commandLine.bundleIdentifier();
+		}
+	}
+
+	private void readConfigJson(File configJson) throws IOException {
+
+		JsonObject json = JsonObject.readFrom(FileUtils.readFileToString(configJson));
+
+		platform = Platform.byDesc(json.get("platform").asString());
+		jdk = json.get("jdk").asString();
+		executable = json.get("executable").asString();
+		classpath = toStringArray(json.get("classpath").asArray());
+		mainClass = json.get("mainclass").asString();
+		if(json.get("vmargs") != null) {
+			List<String> vmArgs = toStringArray(json.get("vmargs").asArray());
+			this.vmArgs = new ArrayList<String>();
+			for (String vmArg : vmArgs) {
+				if (vmArg.startsWith("-")) {
+					this.vmArgs.add(vmArg.substring(1));
+				} else {
+					this.vmArgs.add(vmArg);
+				}
+			}
+		}
+		if(json.get("minimizejre") != null) {
+			minimizeJre = json.get("minimizejre").asString();
+		}
+		if(json.get("resources") != null) {
+			resources = toFileArray(json.get("resources").asArray());
+		}
+		outDir = new File(json.get("output").asString());
+		if(json.get("icon") != null) {
+			iconResource = new File(json.get("icon").asString());
+		}
+		if(json.get("bundle") != null) {
+			bundleIdentifier = json.get("bundle").asString();
+		}
+	}
+
+	private <T> List<T> appendTo(List<T> list, List<T> append) {
+		if (list == null) {
+			return append;
+		}
+
+		for (T item : append) {
+			boolean duplicate = false;
+			for (T cmp : list) {
+				if (cmp.equals(item)) {
+					duplicate = true;
+					break;
+				}
+			}
+			if (!duplicate) {
+				list.add(item);
+			}
+		}
+
+		return list;
+	}
+
+	private List<String> toStringArray(JsonArray array) {
+		List<String> result = new ArrayList<String>();
+		for(JsonValue value: array) {
+			result.add(value.asString());
+		}
+		return result;
+	}
+
+	private List<File> toFileArray(JsonArray array) {
+		List<File> result = new ArrayList<File>();
+		for(JsonValue value: array) {
+			result.add(new File(value.asString()));
+		}
+		return result;
+	}
+
+	/**
+	 * Sanity checks for configuration settings. Because users like to break stuff.
+	 */
+	void validate() throws IOException {
+		if (outDir.exists()) {
+			if (new File(".").equals(outDir)) {
+				throw new IOException("Output directory equals working directory, aborting");
+			}
+			if(new File("/").equals(outDir)) {
+				throw new IOException("Output directory equals root, aborting");
+			}
+		}
+	}
+
+}

--- a/src/main/java/com/badlogicgames/packr/PackrFileUtils.java
+++ b/src/main/java/com/badlogicgames/packr/PackrFileUtils.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogicgames.packr;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Some file utility wrappers to check for function results, and to raise exceptions in case of error.
+ */
+class PackrFileUtils {
+
+	static void mkdirs(File path) throws IOException {
+		if (!path.mkdirs()) {
+			throw new IOException("Can't create folder(s): " + path);
+		}
+	}
+
+	static void chmodX(File path) {
+		if (!path.setExecutable(true)) {
+			System.err.println("Warning! Failed setting executable flag for: " + path);
+		}
+	}
+
+	static void delete(File path) throws IOException {
+		if (!path.delete()) {
+			throw new IOException("Can't delete file or folder: " + path);
+		}
+	}
+
+}

--- a/src/main/java/com/badlogicgames/packr/PackrReduce.java
+++ b/src/main/java/com/badlogicgames/packr/PackrReduce.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogicgames.packr;
+
+import com.eclipsesource.json.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.zeroturnaround.zip.ZipUtil;
+
+import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Functions to reduce package size for both classpath JARs, and the bundled JRE.
+ */
+class PackrReduce {
+
+	static void minimizeJre(File output, PackrConfig config) throws IOException {
+		if (config.minimizeJre == null) {
+			return;
+		}
+
+		System.out.println("Minimizing JRE ...");
+
+		JsonObject minimizeJson = readMinimizeProfile(config);
+		if (minimizeJson != null) {
+			if (config.verbose) {
+				System.out.println("  # Removing files and directories in profile '" + config.minimizeJre + "' ...");
+			}
+
+			JsonArray reduceArray = minimizeJson.get("reduce").asArray();
+			for (JsonValue reduce : reduceArray) {
+				String path = reduce.asObject().get("archive").asString();
+				File file = new File(output, path);
+
+				if (!file.exists()) {
+					if (config.verbose) {
+						System.out.println("  # No file or directory '" + file.getPath() + "' found, skipping");
+					}
+					continue;
+				}
+
+				boolean needsUnpack = !file.isDirectory();
+
+				File fileNoExt = needsUnpack
+						? new File(output, path.contains(".") ? path.substring(0, path.lastIndexOf('.')) : path)
+						: file;
+
+				if (needsUnpack) {
+					if (config.verbose) {
+						System.out.println("  # Unpacking '" + file.getPath() + "' ...");
+					}
+					ZipUtil.unpack(file, fileNoExt);
+				}
+
+				JsonArray removeArray = reduce.asObject().get("paths").asArray();
+				for (JsonValue remove : removeArray) {
+					File removeFile = new File(fileNoExt, remove.asString());
+					if (removeFile.exists()) {
+						if (removeFile.isDirectory()) {
+							FileUtils.deleteDirectory(removeFile);
+						} else {
+							PackrFileUtils.delete(removeFile);
+						}
+					} else {
+						if (config.verbose) {
+							System.out.println("  # No file or directory '" + removeFile.getPath() + "' found");
+						}
+					}
+				}
+
+				if (needsUnpack) {
+					if (config.verbose) {
+						System.out.println("  # Repacking '" + file.getPath() + "' ...");
+					}
+
+					long beforeLen = file.length();
+					PackrFileUtils.delete(file);
+
+					ZipUtil.pack(fileNoExt, file);
+					FileUtils.deleteDirectory(fileNoExt);
+
+					long afterLen = file.length();
+
+					if (config.verbose) {
+						System.out.println("  # " + beforeLen / 1024 + " kb -> " + afterLen / 1024 + " kb");
+					}
+				}
+			}
+
+			JsonArray removeArray = minimizeJson.get("remove").asArray();
+			for (JsonValue remove : removeArray) {
+				String platform = remove.asObject().get("platform").asString();
+
+				if (!matchPlatformString(platform, config)) {
+					continue;
+				}
+
+				JsonArray removeFilesArray = remove.asObject().get("paths").asArray();
+				for (JsonValue removeFile : removeFilesArray) {
+					removeFileWildcard(output, removeFile.asString(), config);
+				}
+			}
+		}
+	}
+
+	private static boolean matchPlatformString(String platform, PackrConfig config) {
+		return "*".equals(platform) || config.platform.desc.contains(platform);
+	}
+
+	private static void removeFileWildcard(File output, String removeFileWildcard, PackrConfig config) throws IOException {
+		if (removeFileWildcard.contains("*")) {
+			String removePath = removeFileWildcard.substring(0, removeFileWildcard.indexOf('*') - 1);
+			String removeSuffix = removeFileWildcard.substring(removeFileWildcard.indexOf('*') + 1);
+
+			File[] files = new File(output, removePath).listFiles();
+			if (files != null) {
+				for (File file : files) {
+					if (removeSuffix.isEmpty() || file.getName().endsWith(removeSuffix)) {
+						removeFile(file, config);
+					}
+				}
+			} else {
+				if (config.verbose) {
+					System.out.println("  # No matching files found in '" + removeFileWildcard + "'");
+				}
+			}
+		} else {
+			removeFile(new File(output, removeFileWildcard), config);
+		}
+	}
+
+	private static void removeFile(File file, PackrConfig config) throws IOException {
+		if (!file.exists()) {
+			if (config.verbose) {
+				System.out.println("  # No file or directory '" + file.getPath() + "' found");
+			}
+			return;
+		}
+
+		if (config.verbose) {
+			System.out.println("  # Removing '" + file.getPath() + "'");
+		}
+
+		if (file.isDirectory()) {
+			FileUtils.deleteDirectory(file);
+		} else {
+			PackrFileUtils.delete(file);
+		}
+	}
+
+	private static JsonObject readMinimizeProfile(PackrConfig config) throws IOException {
+
+		JsonObject json = null;
+
+		if (new File(config.minimizeJre).exists()) {
+			json = JsonObject.readFrom(FileUtils.readFileToString(new File(config.minimizeJre)));
+		} else {
+			InputStream in = Packr.class.getResourceAsStream("/minimize/" + config.minimizeJre);
+			if (in != null) {
+				json = JsonObject.readFrom(new InputStreamReader(in));
+			}
+		}
+
+		if (json == null && config.verbose) {
+			System.out.println("  # No minimize profile '" + config.minimizeJre + "' found");
+		}
+
+		return json;
+	}
+
+	static void removePlatformLibs(File output, PackrConfig config) throws IOException {
+		System.out.println("Removing foreign platform libs ...");
+
+		// let's remove any shared libs not used on the platform, e.g. libGDX/LWJGL natives
+		for (String classpath : config.classpath) {
+			File jar = new File(output, new File(classpath).getName());
+			File jarDir = new File(output, jar.getName() + ".tmp");
+
+			if (config.verbose) {
+				if (jar.isDirectory()) {
+					System.out.println("  # Classpath '" + classpath + "' is a directory");
+				} else {
+					System.out.println("  # Unpacking '" + classpath + "' ...");
+				}
+			}
+
+			if (!jar.isDirectory()) {
+				ZipUtil.unpack(jar, jarDir);
+			}
+
+			Set<String> extensions = new HashSet<String>();
+
+			switch (config.platform) {
+				case Windows32:
+				case Windows64:
+					extensions.add(".dylib");
+					extensions.add(".so");
+					break;
+				case Linux32:
+				case Linux64:
+					extensions.add(".dylib");
+					extensions.add(".dll");
+					break;
+				case MacOS:
+					extensions.add(".dll");
+					extensions.add(".so");
+					break;
+			}
+
+			for (Object obj : FileUtils.listFiles(jarDir, TrueFileFilter.INSTANCE , TrueFileFilter.INSTANCE)) {
+				File file = new File(obj.toString());
+				for (String extension: extensions) {
+					if (file.getName().endsWith(extension)) {
+						if (config.verbose) {
+							System.out.println("  # Removing '" + file.getPath() + "'");
+						}
+						PackrFileUtils.delete(file);
+					}
+				}
+			}
+
+			if (!jar.isDirectory()) {
+				if (config.verbose) {
+					System.out.println("  # Repacking '" + classpath + "' ...");
+				}
+
+				long beforeLen = jar.length();
+				PackrFileUtils.delete(jar);
+
+				ZipUtil.pack(jarDir, jar);
+				FileUtils.deleteDirectory(jarDir);
+
+				long afterLen = jar.length();
+				if (config.verbose) {
+					System.out.println("  # " + beforeLen / 1024 + " kb -> " + afterLen / 1024 + " kb");
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/resources/minimize/hard
+++ b/src/main/resources/minimize/hard
@@ -1,12 +1,51 @@
-jre/lib/rt/com/sun/corba
-jre/lib/rt/com/sun/jmx
-jre/lib/rt/com/sun/jndi 
-jre/lib/rt/com/sun/media
-jre/lib/rt/com/sun/naming
-jre/lib/rt/com/sun/org
-jre/lib/rt/com/sun/rowset
-jre/lib/rt/com/sun/script
-jre/lib/rt/com/sun/xml
-jre/lib/rt/sun/applet
-jre/lib/rt/sun/corba
-jre/lib/rt/sun/management
+{
+  "reduce": [
+    {
+      "archive": "jre/lib/rt.jar",
+      "paths": [
+        "com/sun/corba",
+        "com/sun/jmx",
+        "com/sun/jndi",
+        "com/sun/media",
+        "com/sun/naming",
+        "com/sun/org",
+        "com/sun/rowset",
+        "com/sun/script",
+        "com/sun/xml",
+        "sun/applet",
+        "sun/corba",
+        "sun/management"
+      ]
+    },
+    {
+      "archive": "jre/lib/charsets.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/jsse.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/resources.jar",
+      "paths": [
+      ]
+    }
+  ],
+  "remove": [
+    {
+      "platform": "*",
+      "paths": [
+        "jre/lib/rhino.jar"
+      ]
+    },
+    {
+      "platform": "windows",
+      "paths": [
+        "jre/bin/*.exe",
+        "jre/bin/client"
+      ]
+    }
+  ]
+}

--- a/src/main/resources/minimize/oraclejre8
+++ b/src/main/resources/minimize/oraclejre8
@@ -1,0 +1,113 @@
+{
+  "reduce": [
+    {
+      "archive": "jre/lib/charsets.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/deploy.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/jce.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/jsse.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/resources.jar",
+      "paths": [
+      ]
+    },
+    {
+      "archive": "jre/lib/rt.jar",
+      "paths": [
+      ]
+    }
+  ],
+  "remove": [
+    {
+      "platform": "*",
+      "paths": [
+        "jre/lib/ext",
+        "jre/bin/rmid",
+        "jre/bin/rmiregistry",
+        "jre/bin/tnameserv",
+        "jre/bin/keytool",
+        "jre/bin/policytool",
+        "jre/bin/orbd",
+        "jre/bin/servertool",
+        "jre/bin/javaws",
+        "jre/lib/javaws.jar",
+        "jre/lib/jfr.jar",
+        "jre/lib/oblique-fonts",
+        "jre/lib/desktop",
+        "jre/plugin",
+
+        "jre/THIRDPARTYLICENSEREADME-JAVAFX.txt",
+        "jre/lib/ant-javafx.jar",
+        "jre/lib/javafx.properties",
+        "jre/lib/jfxswt.jar"
+      ]
+    },
+    {
+      "platform": "windows",
+      "paths": [
+        "jre/bin/rmid.exe",
+        "jre/bin/rmiregistry.exe",
+        "jre/bin/tnameserv.exe",
+        "jre/bin/keytool.exe",
+        "jre/bin/kinit.exe",
+        "jre/bin/klist.exe",
+        "jre/bin/ktab.exe",
+        "jre/bin/policytool.exe",
+        "jre/bin/orbd.exe",
+        "jre/bin/servertool.exe",
+        "jre/bin/javaws.exe",
+        "jre/bin/jfr.dll",
+
+        "jre/bin/java.exe",
+        "jre/bin/javaw.exe",
+        "jre/bin/javacpl.exe",
+        "jre/bin/jucheck.exe",
+        "jre/bin/dtplugin",
+        "jre/bin/jabswitch.exe",
+        "jre/bin/java_crw_demo.dll",
+        "jre/bin/JavaAccessBridge-32.dll",
+        "jre/bin/JavaAccessBridge.dll",
+        "jre/bin/JAWTAccessBridge-32.dll",
+        "jre/bin/JAWTAccessBridge.dll",
+        "jre/bin/WindowsAccessBridge-32.dll",
+        "jre/bin/WindowsAccessBridge.dll",
+        "jre/bin/wsdetect.dll",
+        "jre/bin/plugin2",
+        "jre/bin/deploy.dll",
+        "jre/bin/javacpl.cpl",
+        "jre/lib/deploy.jar",
+        "jre/lib/plugin.jar",
+        "jre/lib/deploy",
+
+        "jre/bin/decora-sse.dll",
+        "jre/bin/fxplugins.dll",
+        "jre/bin/glass.dll",
+        "jre/bin/glib-lite.dll",
+        "jre/bin/gstreamer-lite.dll",
+        "jre/bin/javafx-font.dll",
+        "jre/bin/javafx_font_t2k.dll",
+        "jre/bin/javafx-iio.dll",
+        "jre/bin/jfxmedia.dll",
+        "jre/bin/jfxwebkit.dll",
+        "jre/bin/prism_common.dll",
+        "jre/bin/prism-d3d.dll",
+        "jre/bin/prism_es2.dll",
+        "jre/bin/prism_sw.dll"
+      ]
+    }
+  ]
+}

--- a/src/main/resources/minimize/soft
+++ b/src/main/resources/minimize/soft
@@ -1,8 +1,32 @@
-jre/lib/rt/com/sun/corba 
-jre/lib/rt/com/sun/jndi 
-jre/lib/rt/com/sun/media
-jre/lib/rt/com/sun/naming
-jre/lib/rt/com/sun/rowset
-jre/lib/rt/sun/applet
-jre/lib/rt/sun/corba
-jre/lib/rt/sun/management
+{
+  "reduce": [
+    {
+      "archive": "jre/lib/rt.jar",
+      "paths": [
+        "com/sun/corba",
+        "com/sun/jndi",
+        "com/sun/media",
+        "com/sun/naming",
+        "com/sun/rowset",
+        "sun/applet",
+        "sun/corba",
+        "sun/management"
+      ]
+    }
+  ],
+  "remove": [
+    {
+      "platform": "*",
+      "paths": [
+        "jre/lib/rhino.jar"
+      ]
+    },
+    {
+      "platform": "windows",
+      "paths": [
+        "jre/bin/*.exe",
+        "jre/bin/client"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Replaced command line parser, now uses JewelCLI.
- Extracted config & minimization code into separate modules.
- Added more minimize options. Minimize profiles now use a JSON format to utilize these options.
- Aligned command line & JSON parameter names.
- Amended error checks & log output.
- Added 'oraclejre8' minimization profile, following Oracle's rules for JRE redistribution.
- Updated documentation.

2nd part of my packr overhaul. The Java code this time. Please check the diff to README.md to see what has been changed.

The 'hard' minimization profile now scrapes another ~10 megabytes off the JRE by re-packing some additional JAR files. There's also a - still experimental - profile to minimize a Oracle Java 8 JRE.

I don't want to merge this unseen, so let me know what you think.