### PR TITLE
Allow jdk parameter to be a directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ java -jar packr.jar \
 | Parameter | Meaning |
 | --- | --- |
 | platform | one of "windows32", "windows64", "linux32", "linux64", "mac" |
-| jdk | ZIP file location or URL to an OpenJDK or Oracle JDK build containing a JRE. Prebuild OpenJDK packages can be found at https://github.com/alexkasko/openjdk-unofficial-builds |
+| jdk | ZIP file location or URL to ZIP file of an OpenJDK or Oracle JDK build containing a JRE. Prebuild OpenJDK packages can be found at https://github.com/alexkasko/openjdk-unofficial-builds. You can also specify a directory to an unpacked JDK distribution. E.g. using ${java.home} in a build script|
 | executable | name of the native executable, without extension such as ".exe" |
 | classpath | file locations of the JAR files to package |
 | mainclass | the fully qualified name of the main class, using dots to delimit package names |

--- a/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/src/main/java/com/badlogicgames/packr/Packr.java
@@ -215,7 +215,12 @@ public class Packr {
 		System.out.println("Unpacking JRE ...");
 		File tmp = new File(output.resourcesFolder, "tmp");
 		PackrFileUtils.mkdirs(tmp);
-		ZipUtil.unpack(jdkFile, tmp);
+
+		if (jdkFile.isDirectory()) {
+			FileUtils.copyDirectoryToDirectory(jdkFile, tmp);
+		} else {
+			ZipUtil.unpack(jdkFile, tmp);
+		}
 
 		File jre = searchJre(tmp);
 		if (jre == null) {


### PR DESCRIPTION
This allows for packaging with a locally installed JDK without downloading a ZIP file.
E.g. I'm using this from gradle with ${java.home}
