### PR TITLE
Fix crash when classpath is a directory.

### DIFF
--- a/src/main/java/com/badlogicgames/packr/PackrReduce.java
+++ b/src/main/java/com/badlogicgames/packr/PackrReduce.java
@@ -202,6 +202,8 @@ class PackrReduce {
 
 			if (!jar.isDirectory()) {
 				ZipUtil.unpack(jar, jarDir);
+			} else {
+				FileUtils.copyDirectory(jar, jarDir);
 			}
 
 			Set<String> extensions = new HashSet<String>();
@@ -244,13 +246,17 @@ class PackrReduce {
 				PackrFileUtils.delete(jar);
 
 				ZipUtil.pack(jarDir, jar);
-				FileUtils.deleteDirectory(jarDir);
 
 				long afterLen = jar.length();
 				if (config.verbose) {
 					System.out.println("  # " + beforeLen / 1024 + " kb -> " + afterLen / 1024 + " kb");
 				}
+			} else {
+				FileUtils.deleteDirectory (jar);
+				FileUtils.copyDirectory(jarDir, jar);
 			}
+
+			FileUtils.deleteDirectory(jarDir);
 		}
 	}
 


### PR DESCRIPTION
Fix crash when classpath is a directory.

- Allows removing foreign platform libs from a directory classpath
  without crashing.