### PR TITLE
Support new JDK structure + JDK archive (.tar.gz) + real ${JAVA_HOME} JDK config file parameter 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.18</version>
+		</dependency>
+		<dependency>
 			<groupId>org.zeroturnaround</groupId>
 			<artifactId>zt-zip</artifactId>
 			<version>1.10</version>

--- a/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/src/main/java/com/badlogicgames/packr/Packr.java
@@ -38,6 +38,9 @@ import org.zeroturnaround.zip.commons.IOUtils;
  */
 public class Packr {
 
+	public static final String ARCHIVE_POSTFIX_ZIP = ".zip";
+	public static final String ARCHIVE_POSTFIX_TAR_GZ = ".tar.gz";
+	
 	private PackrConfig config;
 
 	@SuppressWarnings("WeakerAccess")
@@ -238,7 +241,11 @@ public class Packr {
 
 			// path to extract JRE from (folder, zip or remote)
 			boolean fetchFromRemote = config.jdk.startsWith("http://") || config.jdk.startsWith("https://");
-			File jdkFile = fetchFromRemote ? new File(jreStoragePath, "jdk.zip") : new File(config.jdk);
+			boolean isZipFile = config.jdk.endsWith(ARCHIVE_POSTFIX_ZIP);
+
+			final String filePostfix = isZipFile ? ARCHIVE_POSTFIX_ZIP : ARCHIVE_POSTFIX_TAR_GZ;
+
+			File jdkFile = fetchFromRemote ? new File(jreStoragePath, "jdk" + filePostfix) : new File(config.jdk);
 
 			// download from remote
 			if (fetchFromRemote) {
@@ -261,13 +268,13 @@ public class Packr {
 			if (jdkFile.isDirectory()) {
 				PackrFileUtils.copyDirectory(jdkFile, tmp);
 			} else {
-				if(config.jdk.endsWith(".zip"))	{
-					System.out.println(".zip file detected.");
+				if(config.jdk.endsWith(ARCHIVE_POSTFIX_ZIP))	{
+					System.out.println(ARCHIVE_POSTFIX_ZIP + " file detected.");
 					ZipUtil.unpack(jdkFile, tmp);
 				} else {
-					if (config.jdk.endsWith(".tar.gz")) {
-						System.out.println(".tar.gz file detected.");
-						decompress(config.jdk, tmp);
+					if (config.jdk.endsWith(ARCHIVE_POSTFIX_TAR_GZ)) {
+						System.out.println(ARCHIVE_POSTFIX_TAR_GZ + " file detected.");
+						decompress(jdkFile.getAbsolutePath(), tmp);
 					} else {
 						throw new IOException("Invalid JRE configuration!");
 					}


### PR DESCRIPTION
Support new JDK structure (Java 9++).
Support .tar.gz files as JDK archives.
Support environment variable definition for JDK in Packr config file: '${JAVA_HOME}' - this is very useful to handle specific JDKs in Jenkins CI.