### PR TITLE
GitHub packages

### DIFF
--- a/Packr/packr.gradle.kts
+++ b/Packr/packr.gradle.kts
@@ -33,11 +33,6 @@ plugins {
 }
 
 repositories {
-   mavenCentral()
-   jcenter()
-   maven(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
-   gitHubRepositoryForPackr(project)
-
    for (repositoryIndex in 0..10) {
       if (project.hasProperty("maven.repository.url.$repositoryIndex") && project.findProperty("maven.repository.isdownload.$repositoryIndex")
             .toString()
@@ -53,6 +48,15 @@ repositories {
          }
       }
    }
+
+   mavenCentral()
+   maven(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
+   jcenter()
+   gitHubRepositoryForPackr(project)
+
+   // temporary for CI publishing until oss.sonatype.org is available for com.libgdx.packr or com.badlogicgames.packr
+   maven("http://artifactory.nimblygames.com/artifactory/ng-public-snapshot/")
+   maven("http://artifactory.nimblygames.com/artifactory/ng-public-release/")
 }
 
 java {
@@ -184,7 +188,7 @@ val syncCurrentOsPackrLaunchers: TaskProvider<Sync> = tasks.register<Sync>("sync
 val packrLauncherDirectory: Path = buildDir.toPath().resolve("packrLauncher")
 
 /**
- * Creates a consolidated directory containing the latest locally build executables and filling in any missing ones with those downloaded from the Maven repository
+ * Creates a consolidated directory containing the latest locally built executables and filling in any missing ones with those downloaded from the Maven repository
  */
 val createPackrLauncherConsolidatedDirectory: TaskProvider<Task> = tasks.register("createPackrLauncherConsolidatedDirectory") {
    dependsOn(syncCurrentOsPackrLaunchers)
@@ -291,7 +295,6 @@ publishing {
                url.set("https://github.com/libgdx/packr")
             }
          }
-
       }
       register<MavenPublication>(project.name) {
          from(components["java"])

--- a/Packr/packr.gradle.kts
+++ b/Packr/packr.gradle.kts
@@ -12,11 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import java.net.URI
+import com.libgdx.gradle.gitHubRepositoryForPackr
+import com.libgdx.gradle.isSnapshot
+import com.libgdx.gradle.packrPublishRepositories
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
@@ -31,17 +32,12 @@ plugins {
    signing
 }
 
-/**
- * URI for the GitHub Packr Maven repository.
- */
-val gitHubPackrMavenUri: URI = uri("https://maven.pkg.github.com/libgdx/packr")
-
 repositories {
    mavenCentral()
    jcenter()
    maven(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
-   // TODO GitHub isn't respecting Maven coordinates and is given errors `Could not GET 'https://maven.pkg.github.com/libgdx/packr/packrLauncher-linux-x86-64/2.8.0-SNAPSHOT/maven-metadata.xml'. Received status code 400 from server: Bad Request`
-   //      maven(gitHubPackrMavenUri)
+   gitHubRepositoryForPackr(project)
+
    for (repositoryIndex in 0..10) {
       if (project.hasProperty("maven.repository.url.$repositoryIndex") && project.findProperty("maven.repository.isdownload.$repositoryIndex")
             .toString()
@@ -67,12 +63,14 @@ java {
 /**
  * The configuration for depending on the Packr Launcher executables
  */
-val packrLauncherMavenRepositoryExecutables = configurations.register("PackrLauncherExecutables")
+val packrLauncherMavenRepositoryExecutables: NamedDomainObjectProvider<Configuration> =
+      configurations.register("PackrLauncherExecutables")
 
 /**
  * Configuration for getting the latest build executables from PackrLauncher project
  */
-val packrLauncherExecutablesForCurrentOs = configurations.register("currentOsPackrLauncherExecutables")
+val packrLauncherExecutablesForCurrentOs: NamedDomainObjectProvider<Configuration> =
+      configurations.register("currentOsPackrLauncherExecutables")
 dependencies {
    //
    implementation("org.apache.commons:commons-compress:1.20")
@@ -119,7 +117,7 @@ java {
 /**
  * Sync the Packr launcher dependencies to the build directory for including into the Jar
  */
-val syncPackrLaunchers = tasks.register<Sync>("syncPackrLaunchers") {
+val syncPackrLaunchers: TaskProvider<Sync> = tasks.register<Sync>("syncPackrLaunchers") {
    dependsOn(packrLauncherMavenRepositoryExecutables)
 
    from(packrLauncherMavenRepositoryExecutables)
@@ -151,7 +149,7 @@ val syncPackrLaunchers = tasks.register<Sync>("syncPackrLaunchers") {
 /**
  * Sync the latest built binaries from the PackrLauncher project
  */
-val syncCurrentOsPackrLaunchers = tasks.register<Sync>("syncCurrentOsPackrLaunchers") {
+val syncCurrentOsPackrLaunchers: TaskProvider<Sync> = tasks.register<Sync>("syncCurrentOsPackrLaunchers") {
    dependsOn(packrLauncherExecutablesForCurrentOs)
 
    from(zipTree(packrLauncherExecutablesForCurrentOs.get().singleFile))
@@ -188,7 +186,7 @@ val packrLauncherDirectory: Path = buildDir.toPath().resolve("packrLauncher")
 /**
  * Creates a consolidated directory containing the latest locally build executables and filling in any missing ones with those downloaded from the Maven repository
  */
-val createPackrLauncherConsolidatedDirectory = tasks.register("createPackrLauncherConsolidatedDirectory") {
+val createPackrLauncherConsolidatedDirectory: TaskProvider<Task> = tasks.register("createPackrLauncherConsolidatedDirectory") {
    dependsOn(syncCurrentOsPackrLaunchers)
    dependsOn(syncPackrLaunchers)
 
@@ -244,44 +242,17 @@ tasks.withType(ShadowJar::class).configureEach {
 /**
  * Configuration for exporting the packr-all jar to other projects in Gradle
  */
-val packrAllConfiguration = configurations.register("packrAll")
+val packrAllConfiguration: NamedDomainObjectProvider<Configuration> = configurations.register("packrAll")
 artifacts {
    add(packrAllConfiguration.name, tasks.named<ShadowJar>("shadowJar").get()) {
       classifier = ""
    }
 }
 
-/**
- * Is the packer version a snapshot or release?
- */
-val isSnapshot = project.version.toString().contains("SNAPSHOT")
-
 publishing {
    repositories {
-      for (repositoryIndex in 0..10) {
-         // @formatter:off
-         if (project.hasProperty("maven.repository.url.$repositoryIndex")
-             && ((project.findProperty("maven.repository.ispublishsnapshot.$repositoryIndex").toString().toBoolean() && isSnapshot)
-                 || (project.findProperty("maven.repository.ispublishrelease.$repositoryIndex").toString().toBoolean() && !isSnapshot))) {
-            // @formatter:on
-            maven {
-               url = uri(project.findProperty("maven.repository.url.$repositoryIndex") as String)
-               credentials {
-                  username = project.findProperty("maven.repository.username.$repositoryIndex") as String
-                  password = project.findProperty("maven.repository.password.$repositoryIndex") as String
-               }
-            }
-         }
-      }
-      // TODO GitHub repository isn't working. It doesn't behave like other Maven repositories (Sonatype or Artifactory).
-      @Suppress("SimplifyBooleanWithConstants") if (false && System.getenv("PACKR_GITHUB_MAVEN_USERNAME")!!.toBoolean()) {
-         maven(gitHubPackrMavenUri) {
-            credentials {
-               username = System.getenv("PACKR_GITHUB_MAVEN_USERNAME")
-               password = System.getenv("PACKR_GITHUB_MAVEN_TOKEN")
-            }
-         }
-      }
+      packrPublishRepositories(project)
+      gitHubRepositoryForPackr(project)
    }
    publications {
       register<MavenPublication>("${project.name}-all") {

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -12,9 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
+import com.libgdx.gradle.gitHubRepositoryForPackr
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.apache.tools.ant.taskdefs.condition.Os.FAMILY_MAC
 import org.apache.tools.ant.taskdefs.condition.Os.FAMILY_UNIX
@@ -41,6 +41,8 @@ repositories {
    maven {
       url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
    }
+   gitHubRepositoryForPackr(project)
+
    for (repositoryIndex in 0..10) {
       if (project.hasProperty("maven.repository.url.$repositoryIndex") && project.findProperty("maven.repository.isdownload.$repositoryIndex")
             .toString()

--- a/PackrLauncher/packrLauncher.gradle.kts
+++ b/PackrLauncher/packrLauncher.gradle.kts
@@ -288,6 +288,28 @@ publishing {
    repositories {
       packrPublishRepositories(project)
       gitHubRepositoryForPackr(project)
+
+      // Inorder to build the packr.jar, executables must be available from all supported platforms.
+      val ngToken: String? =
+            findProperty("NG_ARTIFACT_REPOSITORY_TOKEN") as String? ?: System.getenv("NG_ARTIFACT_REPOSITORY_TOKEN")
+      if (ngToken != null) {
+         val ngUsername = findProperty("NG_ARTIFACT_REPOSITORY_USER") as String? ?: System.getenv("NG_ARTIFACT_REPOSITORY_USER")
+         if (isSnapshot) {
+            maven("http://artifactory.nimblygames.com/artifactory/ng-public-snapshot/") {
+               credentials {
+                  username = ngUsername
+                  password = ngToken
+               }
+            }
+         } else {
+            maven("http://artifactory.nimblygames.com/artifactory/ng-public-release/") {
+               credentials {
+                  username = ngUsername
+                  password = ngToken
+               }
+            }
+         }
+      }
    }
    publications {
       configureEach {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+   `kotlin-dsl`
+}
+
+repositories {
+   jcenter()
+}

--- a/buildSrc/src/main/kotlin/com/libgdx/gradle/Projects.kt
+++ b/buildSrc/src/main/kotlin/com/libgdx/gradle/Projects.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.libgdx.gradle
+
+import org.gradle.api.Project
+
+/**
+ * Is the [Project.getVersion] a snapshot? E.g., does it contain `SNAPSHOT`
+ */
+val Project.isSnapshot: Boolean
+   get() = version.toString().contains("SNAPSHOT")

--- a/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
@@ -46,6 +46,9 @@ val Project.gitHubMavenToken: String?
  */
 fun RepositoryHandler.gitHubRepositoryForPackr(project: Project) {
    if (project.gitHubMavenUsername != null) {
+      val tokenLength = project.gitHubMavenToken?.length ?: 0
+      project.logger.error("Adding GitHub repository $gitHubPackrMavenUri, username=`${project.gitHubMavenUsername}`, token=`${project.gitHubMavenToken?.substring(
+            0..3)}...${project.gitHubMavenToken?.substring(tokenLength - 4, tokenLength - 1)}`")
       maven {
          url = gitHubPackrMavenUri
          credentials {

--- a/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.libgdx.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import java.net.URI
+
+/**
+ * URI for the GitHub Packr Maven repository.
+ */
+val gitHubPackrMavenUri: URI = URI("https://maven.pkg.github.com/libgdx/packr")
+
+/**
+ * Username for signing into GitHub Maven packages url [gitHubPackrMavenUri]. The username is loaded from the Gradle property or
+ * environment variable `PACKR_GITHUB_MAVEN_USERNAME`.
+ */
+val Project.gitHubMavenUsername: String?
+   get() {
+      return findProperty("PACKR_GITHUB_MAVEN_USERNAME") as String? ?: System.getenv("PACKR_GITHUB_MAVEN_USERNAME")
+   }
+
+/**
+ * Authentication token for signing into GitHub Maven packages url [gitHubPackrMavenUri]. The token is loaded from the Gradle
+ * property or environment variable `PACKR_GITHUB_MAVEN_TOKEN`
+ */
+val Project.gitHubMavenToken: String?
+   get() = this.findProperty("PACKR_GITHUB_MAVEN_TOKEN") as String? ?: System.getenv("PACKR_GITHUB_MAVEN_TOKEN")
+
+/**
+ * Adds the GitHub Maven repository for [gitHubPackrMavenUri] only if the [gitHubMavenUsername] is non null.
+ */
+fun RepositoryHandler.gitHubRepositoryForPackr(project: Project) {
+   if (project.gitHubMavenUsername != null) {
+      maven {
+         url = gitHubPackrMavenUri
+         credentials {
+            username = project.gitHubMavenUsername
+            password = project.gitHubMavenToken
+         }
+      }
+   }
+}
+
+/**
+ * Searches for Gradle properties of Maven repositories to publish to.
+ *
+ * The properties are:
+ * * `maven.repository.url.n=<url>` // This is the Maven repository url
+ * * `maven.repository.ispublishsnapshot.n=<boolean>` // true if snapshot builds should be published to this repository
+ * * `maven.repository.ispublishrelease.n=<boolean>` // true if release builds should be published to this repository
+ * * `maven.repository.ispublishpackr.n=<boolean>` // true if packr builds should be published to this repository
+ * * `maven.repository.username.n=<username>` // The username for authenticating to the Maven repository
+ * * `maven.repository.password.n=<password` // The token or password for authenticating to the Maven repository
+ *
+ * Example:
+ * ```text
+ * maven.repository.url.1=https://oss.sonatype.org/content/repositories/snapshots
+ * maven.repository.username.1=tstark
+ * maven.repository.password.1=mark42
+ * maven.repository.ispublishsnapshot.1=true
+ * maven.repository.ispublishrelease.1=false
+ * maven.repository.ispublishpackr.1=true
+ * ```
+ */
+fun RepositoryHandler.packrPublishRepositories(project: Project) {
+   for (repositoryIndex in 0..10) {
+      // @off
+      if (project.hasProperty("maven.repository.url.$repositoryIndex")
+          && ((project.findProperty("maven.repository.ispublishsnapshot.$repositoryIndex").toString().toBoolean() && project.isSnapshot)
+              || (project.findProperty("maven.repository.ispublishrelease.$repositoryIndex").toString().toBoolean() && !project.isSnapshot))
+          && project.findProperty("maven.repository.ispublishpackr.$repositoryIndex").toString().toBoolean()) {
+         // @on
+         maven {
+            url = URI(project.findProperty("maven.repository.url.$repositoryIndex") as String)
+            credentials {
+               username = project.findProperty("maven.repository.username.$repositoryIndex") as String
+               password = project.findProperty("maven.repository.password.$repositoryIndex") as String
+            }
+         }
+      }
+   }
+}

--- a/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
@@ -45,7 +45,7 @@ val Project.gitHubMavenToken: String?
  * Adds the GitHub Maven repository for [gitHubPackrMavenUri] only if the [gitHubMavenUsername] is non null.
  */
 fun RepositoryHandler.gitHubRepositoryForPackr(project: Project) {
-   if (project.gitHubMavenUsername != null) {
+   if (project.gitHubMavenToken != null) {
       val tokenLength = project.gitHubMavenToken?.length ?: 0
       project.logger.error("Adding GitHub repository $gitHubPackrMavenUri, username=`${project.gitHubMavenUsername}`, token=`${project.gitHubMavenToken?.substring(
             0..3)}...${project.gitHubMavenToken?.substring(tokenLength - 4, tokenLength - 1)}`")


### PR DESCRIPTION
Added publishing to GitHub packages, but ran into an issue with the way they handle maven-metadata.xml.

Trying to get the url `https://maven.pkg.github.com/libgdx/packr/com/badlogicgames/packr/packrLauncher-linux-x86-64/3.0.0-SNAPSHOT/maven-metadata.xml` results in an error `error retrieving metadata for snapshot file: packrLauncher-linux-x86-64-3.0.0-20200910.045230-1`

For now, added publishing to my artifact server until authorized to publish to oss.sonatype.org.