### PR TITLE
Remove publishing of executables to GitHub

### DIFF
--- a/PackrLauncher/packrLauncher.gradle.kts
+++ b/PackrLauncher/packrLauncher.gradle.kts
@@ -16,7 +16,6 @@
 
 @file:Suppress("UnstableApiUsage")
 
-import com.libgdx.gradle.gitHubRepositoryForPackr
 import com.libgdx.gradle.isSnapshot
 import com.libgdx.gradle.packrPublishRepositories
 import org.gradle.internal.jvm.Jvm
@@ -287,7 +286,12 @@ artifacts {
 publishing {
    repositories {
       packrPublishRepositories(project)
-      gitHubRepositoryForPackr(project)
+      /*
+       * Publishing to GitHub for the executables is causing issues:
+       * Could not GET 'https://maven.pkg.github.com/libgdx/packr/com/badlogicgames/packr/packrLauncher-linux-x86-64/3.0.0-SNAPSHOT/maven-metadata.xml'.
+       * Received status code 400 from server: Bad Request
+       */
+      //      gitHubRepositoryForPackr(project)
 
       // Inorder to build the packr.jar, executables must be available from all supported platforms.
       val ngToken: String? =

--- a/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/com/libgdx/gradle/Repositories.kt
@@ -46,9 +46,6 @@ val Project.gitHubMavenToken: String?
  */
 fun RepositoryHandler.gitHubRepositoryForPackr(project: Project) {
    if (project.gitHubMavenToken != null) {
-      val tokenLength = project.gitHubMavenToken?.length ?: 0
-      project.logger.error("Adding GitHub repository $gitHubPackrMavenUri, username=`${project.gitHubMavenUsername}`, token=`${project.gitHubMavenToken?.substring(
-            0..3)}...${project.gitHubMavenToken?.substring(tokenLength - 4, tokenLength - 1)}`")
       maven {
          url = gitHubPackrMavenUri
          credentials {


### PR DESCRIPTION
Publishing Jars is working fine for GitHub packages, it's only the executable files that are having issues.