### PR TITLE
No longer delete the output folder

### DIFF
--- a/Packr/src/test/java/com/badlogicgames/packr/PackrTest.java
+++ b/Packr/src/test/java/com/badlogicgames/packr/PackrTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 See AUTHORS file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.badlogicgames.packr;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class PackrTest {
+
+	 @Test void verifyEmptyOrCreateOutputFolderCreated (@TempDir Path tempDirectoryPath) throws IOException {
+		  Packr packr = new Packr();
+		  Path outputPath = tempDirectoryPath.resolve("output");
+		  PackrOutput packrOutput = new PackrOutput(outputPath.toFile(), outputPath.toFile());
+		  packr.verifyEmptyOrCreateOutputFolder(packrOutput);
+		  assertTrue(Files.exists(outputPath));
+	 }
+
+	 @Test void verifyEmptyOrCreateOutputFolderEmpty (@TempDir Path tempDirectoryPath) throws IOException {
+		  Packr packr = new Packr();
+		  Path outputPath = tempDirectoryPath.resolve("output");
+		  Files.createDirectories(outputPath);
+		  PackrOutput packrOutput = new PackrOutput(outputPath.toFile(), outputPath.toFile());
+		  packr.verifyEmptyOrCreateOutputFolder(packrOutput);
+		  assertTrue(Files.exists(outputPath));
+		  try (Stream<Path> walk = Files.walk(outputPath, 1)) {
+				assertEquals(walk.count(), 1);
+		  }
+	 }
+
+	 @Test void verifyEmptyOrCreateOutputFolderThrowsNotEmpty (@TempDir Path tempDirectoryPath) throws IOException {
+		  Packr packr = new Packr();
+		  Path outputPath = tempDirectoryPath.resolve("output");
+		  Files.createDirectories(outputPath);
+		  Path someFileThatIsInOutputDir = outputPath.resolve("someFile.txt");
+		  Files.write(someFileThatIsInOutputDir, "Hello world!".getBytes(StandardCharsets.UTF_8));
+		  PackrOutput packrOutput = new PackrOutput(outputPath.toFile(), outputPath.toFile());
+		  try {
+				packr.verifyEmptyOrCreateOutputFolder(packrOutput);
+		  } catch (IOException exception) {
+				assertTrue(exception.getMessage().contains("is not empty"));
+				return;
+		  }
+		  fail("Should have thrown a not empty exception");
+	 }
+
+	 @Test void verifyEmptyOrCreateOutputFolderThrowsIsFile (@TempDir Path tempDirectoryPath) throws IOException {
+		  Packr packr = new Packr();
+		  Path outputPath = tempDirectoryPath.resolve("output");
+		  Files.write(outputPath, "Hello world!".getBytes(StandardCharsets.UTF_8));
+		  PackrOutput packrOutput = new PackrOutput(outputPath.toFile(), outputPath.toFile());
+		  try {
+				packr.verifyEmptyOrCreateOutputFolder(packrOutput);
+		  } catch (IOException exception) {
+				assertTrue(exception.getMessage().contains("is not a directory"));
+				return;
+		  }
+		  fail("Should have thrown a not empty exception");
+	 }
+}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ java -jar packr-all.jar \
 | useZgcIfSupportedOs | When bundling a Java 14+ JRE, the launcher will check if the operating system supports the [Z garbage collector](https://wiki.openjdk.java.net/display/zgc/Main) and use it. At the time of this writing, the supported operating systems are Linux, macOS, and Windows version 1803 (Windows 10 or Windows Server 2019) or later." |
 | resources (optional) | list of files and directories to be packaged next to the native executable |
 | minimizejre | minimize the JRE by removing directories and files as specified by an additional config file. Comes with a few config files out of the box. See below for details on the minimization config file. |
-| output | the output directory |
+| output | the output directory. This must be an existing empty directory or a path that does not exist. Packr will create the directory if it doesn't exist but will fail if the path is not a directory or is not an empty directory. |
 | cachejre (optional) | An optional directory to cache the result of JRE extraction and minimization. See below for details. |
 | icon (optional, OS X) | location of an AppBundle icon resource (.icns file) |
 | bundle (optional, OS X) | the bundle identifier of your Java application, e.g. "com.my.app" |

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Release 3.0.0-SNAPSHOT
 1. Refactored code to fit better into libGdx/packr parent repository.
 1. Fixed an issue where extracting an archive with duplicate entries would fail.
-1. The packr-all Jar is published to GitHub packages <https://github.com/libgdx/packr/packages>.
+1. The packr-all Jar is available from GitHub packages <https://github.com/libgdx/packr/packages>.
+1. The output directory specified by `--output` must be an empty directory, or a path that does not exist.
+   * Packr will no longer delete the output directory and then populate it.
 # Release 2.7.0
 1. Fixed a Gradle script error where it was bundling the release builds with debug info on Linux and macOS.
    * For Linux this reduces the executable size from ~722K to ~95K.


### PR DESCRIPTION
Deleting the output directory without obvious user consent is undesired behavior. 

Packr will now fail if the output directory is not empty or does not exist.

Resolves #154
