### PR TITLE
jspawnhelper execute permissions

### DIFF
--- a/Packr/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/Packr/src/main/java/com/badlogicgames/packr/Packr.java
@@ -52,6 +52,7 @@ import static com.badlogicgames.packr.ArchiveUtils.extractArchive;
  */
 public class Packr {
 
+	 public static final String JRE_RELATIVE_PATH_NAME = "jre";
 	 private PackrConfig config;
 	 private Predicate<File> removePlatformLibsFileFilter = f -> false;
 
@@ -408,7 +409,7 @@ public class Packr {
 					 throw new IOException("Couldn't find JRE in JDK, see '" + tmp.getAbsolutePath() + "'");
 				}
 
-				PackrFileUtils.copyDirectory(jre, new File(jreStoragePath, "jre"));
+				PackrFileUtils.copyDirectory(jre, new File(jreStoragePath, JRE_RELATIVE_PATH_NAME));
 				PackrFileUtils.deleteDirectory(tmp);
 
 				if (fetchFromRemote) {
@@ -424,6 +425,15 @@ public class Packr {
 				// this is the only copy done (and everything above is skipped)
 				PackrFileUtils.copyDirectory(jreStoragePath, output.resourcesFolder);
 		  }
+
+		  Files.walkFileTree(output.resourcesFolder.toPath().resolve(JRE_RELATIVE_PATH_NAME), new SimpleFileVisitor<Path>() {
+				@Override public FileVisitResult visitFile (Path file, BasicFileAttributes attrs) throws IOException {
+					 if (file.getFileName().toString().equals("jspawnhelper")) {
+						  PackrFileUtils.chmodX(file.toFile());
+					 }
+					 return super.visitFile(file, attrs);
+				}
+		  });
 	 }
 
 	 /**

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -202,9 +202,9 @@ val createTestDirectory: TaskProvider<Task> = tasks.register("createTestDirector
                errorOutput = errorOutputCapture
                isIgnoreExitValue = true
             }
-            val outputAsString = standardOutputCapture.toString(Charsets.UTF_8)
+            val outputAsString = standardOutputCapture.toByteArray().toString(Charsets.UTF_8)
             logger.info("Captured standard output:\n$outputAsString")
-            val errorAsString = errorOutputCapture.toString(Charsets.UTF_8)
+            val errorAsString = errorOutputCapture.toByteArray().toString(Charsets.UTF_8)
             logger.info("Captured error output:\n$errorAsString")
 
             if (!outputAsString.contains("Hello world!")) {

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -77,12 +77,12 @@ java {
 /**
  * Configuration for consuming all the artifacts produced by TestAppJreDist
  */
-val jdksAndJresFromJreDist = configurations.register("jdksAndJresFromJreDist")
+val jdksAndJresFromJreDist: NamedDomainObjectProvider<Configuration> = configurations.register("jdksAndJresFromJreDist")
 
 /**
  * The configuration for depending on the Packr Launcher executables
  */
-val packrAllArchive = configurations.register("packrAllArchive")
+val packrAllArchive: NamedDomainObjectProvider<Configuration> = configurations.register("packrAllArchive")
 dependencies {
    // test
    testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
@@ -165,7 +165,7 @@ val createTestDirectory: TaskProvider<Task> = tasks.register("createTestDirector
          if (isFamily(FAMILY_UNIX)) {
             Files.walkFileTree(packrOutputDirectory, object : SimpleFileVisitor<Path>() {
                override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-                  if (file.fileName.toString().equals("java")) {
+                  if (file.fileName.toString() == "java") {
                      exec {
                         executable = "chmod"
                         args("+x")
@@ -236,7 +236,7 @@ tasks.named("check") {
 /**
  * Gradle property specifying where the JDK archives directory is
  */
-val jdkArchiveProperty = findProperty("jdk.archive.directory") as String?
+val jdkArchiveProperty: String? = findProperty("jdk.archive.directory") as String?
 
 /**
  * Path to a directory containing any number of JDK archives to test.

--- a/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
+++ b/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
@@ -18,33 +18,38 @@ package com.badlogicgames.packrtestapp;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
  * Simple hello world application for testing the packr launcher.
  */
 public class PackrAllTestApplication {
-    /**
-     * Main CLI entrance.
-     *
-     * @param args ignored
-     *
-     * @throws IOException if an IO error occurs
-     */
-    public static void main (String[] args) throws IOException {
-        System.out.println("Hello world!");
-        System.out.println("Running from java.version=" + System.getProperty("java.version"));
+	 /**
+	  * Main CLI entrance.
+	  *
+	  * @param args ignored
+	  *
+	  * @throws IOException if an IO error occurs
+	  */
+	 public static void main (String[] args) throws IOException, InterruptedException {
+		  System.out.println("Hello world!");
+		  System.out.println("Running from java.version=" + System.getProperty("java.version"));
 
-        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
-            System.out.println(
-               "Received uncaught exception in thread.getName()=" + thread.getName() + ", Thread.currentThread().getName()=" + Thread.currentThread()
-                  .getName());
-            throwable.printStackTrace(System.out);
-        });
+		  Path javaExecutablePath = Paths.get(System.getProperty("java.home")).resolve("bin").resolve("java");
+		  new ProcessBuilder(javaExecutablePath.toString(), "-version").inheritIO().start().waitFor();
 
-        Files.lines(Paths.get("application-resources").resolve("fake-resource.txt"))
-           .forEach(resourceLine -> System.out.println("Loaded resource line: " + resourceLine));
+		  Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+				System.out.println(
+					"Received uncaught exception in thread.getName()=" + thread.getName() + ", Thread.currentThread().getName()=" + Thread.currentThread()
+						.getName());
+				throwable.printStackTrace(System.out);
+		  });
 
-        throw new RuntimeException("Testing uncaught exception handler. Thrown from the main thread, Thread.currentThread().getName()=" + Thread.currentThread().getName());
-    }
+		  Files.lines(Paths.get("application-resources").resolve("fake-resource.txt"))
+			  .forEach(resourceLine -> System.out.println("Loaded resource line: " + resourceLine));
+
+		  throw new RuntimeException(
+			  "Testing uncaught exception handler. Thrown from the main thread, Thread.currentThread().getName()=" + Thread.currentThread().getName());
+	 }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@
 1. The packr-all Jar is available from GitHub packages <https://github.com/libgdx/packr/packages>.
 1. The output directory specified by `--output` must be an empty directory, or a path that does not exist.
    * Packr will no longer delete the output directory and then populate it.
+1. Packr will ensure that `jspawnhelper` has execute permissions in the bundled JRE.
+   * This resolves an issue on macOS where Runtime.exec and Process.start calls would fail with `java.io.IOException: Cannot run program "java": error=2, No such file or directory`.
+      * Reference: <https://stackoverflow.com/questions/53113127/java-runtime-exec-fails-to-run/55091040>
 # Release 2.7.0
 1. Fixed a Gradle script error where it was bundling the release builds with debug info on Linux and macOS.
    * For Linux this reduces the executable size from ~722K to ~95K.


### PR DESCRIPTION
If the jre/lib/jspawnhelper executable doesn't have execute permissions, calling Runtime.exec, Process.start, etc. will fail. This patch sets jspawnhelper to executable after jre extraction.