### PR TITLE
Preemtive DLL loading

### DIFF
--- a/Packr/packr.gradle.kts
+++ b/Packr/packr.gradle.kts
@@ -55,8 +55,8 @@ repositories {
    gitHubRepositoryForPackr(project)
 
    // temporary for CI publishing until oss.sonatype.org is available for com.libgdx.packr or com.badlogicgames.packr
-   maven("http://artifactory.nimblygames.com/artifactory/ng-public-snapshot/")
-   maven("http://artifactory.nimblygames.com/artifactory/ng-public-release/")
+   maven("https://artifactory.nimblygames.com/artifactory/ng-public-snapshot/")
+   maven("https://artifactory.nimblygames.com/artifactory/ng-public-release/")
 }
 
 java {
@@ -264,14 +264,14 @@ publishing {
       if (ngToken != null) {
          val ngUsername = findProperty("NG_ARTIFACT_REPOSITORY_USER") as String? ?: System.getenv("NG_ARTIFACT_REPOSITORY_USER")
          if (isSnapshot) {
-            maven("http://artifactory.nimblygames.com/artifactory/ng-public-snapshot/") {
+            maven("https://artifactory.nimblygames.com/artifactory/ng-public-snapshot/") {
                credentials {
                   username = ngUsername
                   password = ngToken
                }
             }
          } else {
-            maven("http://artifactory.nimblygames.com/artifactory/ng-public-release/") {
+            maven("https://artifactory.nimblygames.com/artifactory/ng-public-release/") {
                credentials {
                   username = ngUsername
                   password = ngToken

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -216,6 +216,9 @@ val createTestDirectory: TaskProvider<Task> = tasks.register("createTestDirector
             if (!outputAsString.contains("Received uncaught exception")) {
                throw GradleException("Packr bundle in $packrOutputDirectory didn't catch an unchecked exception with setDefaultUncaughtExceptionHandler")
             }
+            if (!outputAsString.contains("Testing uncaught exception handler.")) {
+               throw GradleException("Packr bundle in $packrOutputDirectory didn't throw \"Testing uncaught exception handler.\"")
+            }
             if (fileNameNoExtension.toLowerCase()
                    .contains("jdk14") && !outputAsString.contains("Using The Z Garbage Collector")) {
                throw GradleException("Packr bundle in $packrOutputDirectory didn't execute using the Z garbage collector")

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -309,6 +309,8 @@ fun createPackrContent(jdkPath: Path, osFamily: String, destination: Path) {
       args("--vmargs")
       args("Dsun.java2d.noddraw=true")
       args("--vmargs")
+      args("Djava.awt.headless=true")
+      args("--vmargs")
       args("XstartOnFirstThread")
       if (jdkPath.fileName.toString().toLowerCase().contains("jdk14")) {
          args("--useZgcIfSupportedOs")

--- a/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
+++ b/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
@@ -16,10 +16,13 @@
 
 package com.badlogicgames.packrtestapp;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 /**
  * Simple hello world application for testing the packr launcher.
@@ -33,6 +36,13 @@ public class PackrAllTestApplication {
 	  * @throws IOException if an IO error occurs
 	  */
 	 public static void main (String[] args) throws IOException, InterruptedException {
+		  JFrame myFrame = new JFrame("Hello");
+		  myFrame.getContentPane().add(new JLabel("Hello world!"));
+		  myFrame.pack();
+		  myFrame.setLocationRelativeTo(null);
+		  myFrame.setVisible(false);
+		  myFrame.dispose();
+
 		  System.out.println("Hello world!");
 		  System.out.println("Running from java.version=" + System.getProperty("java.version"));
 
@@ -46,8 +56,9 @@ public class PackrAllTestApplication {
 				throwable.printStackTrace(System.out);
 		  });
 
-		  Files.lines(Paths.get("application-resources").resolve("fake-resource.txt"))
-			  .forEach(resourceLine -> System.out.println("Loaded resource line: " + resourceLine));
+		  try (Stream<String> lineStream = Files.lines(Paths.get("application-resources").resolve("fake-resource.txt"))) {
+				lineStream.forEach(resourceLine -> System.out.println("Loaded resource line: " + resourceLine));
+		  }
 
 		  throw new RuntimeException(
 			  "Testing uncaught exception handler. Thrown from the main thread, Thread.currentThread().getName()=" + Thread.currentThread().getName());

--- a/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
+++ b/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
@@ -35,7 +35,7 @@ public class PackrAllTestApplication {
 	  * @throws IOException if an IO error occurs
 	  */
 	 public static void main (String[] args) throws IOException, InterruptedException {
-		  System.out.println("ScreenSize=" + Toolkit.getDefaultToolkit().getScreenSize());
+		  System.out.println("EventQueue=" + Toolkit.getDefaultToolkit().getSystemEventQueue());
 
 		  System.out.println("Hello world!");
 		  System.out.println("Running from java.version=" + System.getProperty("java.version"));

--- a/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
+++ b/PackrAllTestApp/src/main/java/com/badlogicgames/packrtestapp/PackrAllTestApplication.java
@@ -16,8 +16,7 @@
 
 package com.badlogicgames.packrtestapp;
 
-import javax.swing.JFrame;
-import javax.swing.JLabel;
+import java.awt.Toolkit;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,12 +35,7 @@ public class PackrAllTestApplication {
 	  * @throws IOException if an IO error occurs
 	  */
 	 public static void main (String[] args) throws IOException, InterruptedException {
-		  JFrame myFrame = new JFrame("Hello");
-		  myFrame.getContentPane().add(new JLabel("Hello world!"));
-		  myFrame.pack();
-		  myFrame.setLocationRelativeTo(null);
-		  myFrame.setVisible(false);
-		  myFrame.dispose();
+		  System.out.println("ScreenSize=" + Toolkit.getDefaultToolkit().getScreenSize());
 
 		  System.out.println("Hello world!");
 		  System.out.println("Running from java.version=" + System.getProperty("java.version"));
@@ -50,8 +44,8 @@ public class PackrAllTestApplication {
 		  new ProcessBuilder(javaExecutablePath.toString(), "-version").inheritIO().start().waitFor();
 
 		  Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
-				System.out.println(
-					"Received uncaught exception in thread.getName()=" + thread.getName() + ", Thread.currentThread().getName()=" + Thread.currentThread()
+				System.out
+					.println("Received uncaught exception in thread.getName()=" + thread.getName() + ", Thread.currentThread().getName()=" + Thread.currentThread()
 						.getName());
 				throwable.printStackTrace(System.out);
 		  });

--- a/PackrLauncher/packrLauncher.gradle.kts
+++ b/PackrLauncher/packrLauncher.gradle.kts
@@ -299,14 +299,14 @@ publishing {
       if (ngToken != null) {
          val ngUsername = findProperty("NG_ARTIFACT_REPOSITORY_USER") as String? ?: System.getenv("NG_ARTIFACT_REPOSITORY_USER")
          if (isSnapshot) {
-            maven("http://artifactory.nimblygames.com/artifactory/ng-public-snapshot/") {
+            maven("https://artifactory.nimblygames.com/artifactory/ng-public-snapshot/") {
                credentials {
                   username = ngUsername
                   password = ngToken
                }
             }
          } else {
-            maven("http://artifactory.nimblygames.com/artifactory/ng-public-release/") {
+            maven("https://artifactory.nimblygames.com/artifactory/ng-public-release/") {
                credentials {
                   username = ngUsername
                   password = ngToken

--- a/TestAppJreDist/testAppJreDist.gradle.kts
+++ b/TestAppJreDist/testAppJreDist.gradle.kts
@@ -332,6 +332,8 @@ extractJdkTasks.forEach { extractJdkTask ->
             args(jlinkPath.toAbsolutePath().toString())
             args("--add-modules")
             args("java.base")
+            args("--add-modules")
+            args("java.desktop")
          }
       }
    }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Unreleased 3.0.2
+1. Preemptively load all DLLs in the jre/bin directory on Windows.
+   * This resolves an issue on Windows where the awt.dll cannot find the Microsoft runtime libraries (MSVCP140.dll).
 # Release 3.0.1
 1. Updated tests to use the latest versions of AdoptOpenJDK 8, 11, and 15.
 1. Changed DLL loading on Windows to search in the JRE bin and server directories.


### PR DESCRIPTION
Load all the DLLs in jre/bin on Windows. For unknown reasons calling AddDllDirectory and SetDllDirectory didn't help the AWT code find and load its dependent MSVCP140.dll.

Closes #178