### PR TITLE
Add jrePath option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Mario Zechner, badlogic, contact at badlogicgames dot com
 Daniel Ludwig, code-disaster, codi at code-disaster dot com
 Karl Sabo, Nimbly Games, karl@nimblygames.com
+petoncle, albert.petoncle47@gmail.com

--- a/Packr/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/Packr/src/main/java/com/badlogicgames/packr/Packr.java
@@ -30,6 +30,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -340,7 +341,7 @@ public class Packr {
 		  builder.append("  ]\n");
 		  builder.append("}");
 
-		  try (Writer writer = new FileWriter(new File(output.resourcesFolder, "config.json"))) {
+		  try (Writer writer = new OutputStreamWriter(new FileOutputStream(new File(output.resourcesFolder, "config.json")), StandardCharsets.UTF_8)) {
 				writer.write(builder.toString());
 		  }
 	 }

--- a/Packr/src/main/java/com/badlogicgames/packr/Packr.java
+++ b/Packr/src/main/java/com/badlogicgames/packr/Packr.java
@@ -53,7 +53,6 @@ import static com.badlogicgames.packr.ArchiveUtils.extractArchive;
  */
 public class Packr {
 
-	 public static final String JRE_RELATIVE_PATH_NAME = "jre";
 	 private PackrConfig config;
 	 private Predicate<File> removePlatformLibsFileFilter = f -> false;
 
@@ -312,6 +311,7 @@ public class Packr {
 	 private void writeConfig (PackrOutput output) throws IOException {
 		  StringBuilder builder = new StringBuilder();
 		  builder.append("{\n");
+		  builder.append("  \"jrePath\": \"").append(config.jrePath).append("\",\n");
 		  builder.append("  \"classPath\": [");
 
 		  String delimiter = "\n";
@@ -410,7 +410,7 @@ public class Packr {
 					 throw new IOException("Couldn't find JRE in JDK, see '" + tmp.getAbsolutePath() + "'");
 				}
 
-				PackrFileUtils.copyDirectory(jre, new File(jreStoragePath, JRE_RELATIVE_PATH_NAME));
+				PackrFileUtils.copyDirectory(jre, new File(jreStoragePath, config.jrePath));
 				PackrFileUtils.deleteDirectory(tmp);
 
 				if (fetchFromRemote) {
@@ -427,7 +427,7 @@ public class Packr {
 				PackrFileUtils.copyDirectory(jreStoragePath, output.resourcesFolder);
 		  }
 
-		  Files.walkFileTree(output.resourcesFolder.toPath().resolve(JRE_RELATIVE_PATH_NAME), new SimpleFileVisitor<Path>() {
+		  Files.walkFileTree(output.resourcesFolder.toPath().resolve(config.jrePath), new SimpleFileVisitor<Path>() {
 				@Override public FileVisitResult visitFile (Path file, BasicFileAttributes attrs) throws IOException {
 					 final String parentFilename = file.getParent().getFileName().toString();
 					 final String filename = file.getFileName().toString();

--- a/Packr/src/main/java/com/badlogicgames/packr/PackrCommandLine.java
+++ b/Packr/src/main/java/com/badlogicgames/packr/PackrCommandLine.java
@@ -73,4 +73,7 @@ public interface PackrCommandLine {
 		 defaultToNull = true) String bundleIdentifier ();
 
 	 @Option(description = "use ZGC if the operating system supports it", longName = "useZgcIfSupportedOs") boolean useZgcIfSupportedOs ();
+
+	 @Option(description = "path to bundled JRE (path separator must be forward slash /)",
+			longName = "jrePath", defaultValue = "jre") String jrePath ();
 }

--- a/Packr/src/main/java/com/badlogicgames/packr/PackrConfig.java
+++ b/Packr/src/main/java/com/badlogicgames/packr/PackrConfig.java
@@ -51,6 +51,7 @@ import java.util.List;
 	 public String bundleIdentifier;
 	 public boolean verbose;
 	 public boolean useZgcIfSupportedOs;
+	 public String jrePath;
 
 	 @SuppressWarnings("unused") public PackrConfig () {
 		  super();
@@ -130,6 +131,8 @@ import java.util.List;
 		  if (commandLine.useZgcIfSupportedOs()) {
 				useZgcIfSupportedOs = true;
 		  }
+
+		  jrePath = commandLine.jrePath();
 	 }
 
 	 private void readConfigJson (File configJson) throws IOException {

--- a/Packr/src/main/java/com/badlogicgames/packr/PackrConfig.java
+++ b/Packr/src/main/java/com/badlogicgames/packr/PackrConfig.java
@@ -151,6 +151,9 @@ import java.util.List;
 		  if (json.get("classpath") != null) {
 				classpath = toStringArray(json.get("classpath").asArray());
 		  }
+		 if (json.get("jrePath") != null) {
+			 	jrePath = json.get("jrePath").asString();
+		 }
 		  if (json.get("removelibs") != null) {
 				removePlatformLibs = toStringArray(json.get("removelibs").asArray());
 		  }

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -287,6 +287,9 @@ fun createPackrContent(jdkPath: Path, osFamily: String, destination: Path) {
       args(jdkPath.toFile())
       args("--executable")
       args("PackrAllTestApp")
+      args("--jrePath")
+      // Tests a custom jre path.
+      args("jre-123456")
       args("--classpath")
       Files.walk(jarTask.get().destinationDirectory.asFile.get().toPath()).use { pathStream ->
          pathStream.forEach { path ->

--- a/PackrAllTestApp/packrAllTestApp.gradle.kts
+++ b/PackrAllTestApp/packrAllTestApp.gradle.kts
@@ -289,7 +289,7 @@ fun createPackrContent(jdkPath: Path, osFamily: String, destination: Path) {
       args("PackrAllTestApp")
       args("--jrePath")
       // Tests a custom jre path.
-      args("jre-123456")
+      args("jre/123456Ä/")
       args("--classpath")
       Files.walk(jarTask.get().destinationDirectory.asFile.get().toPath()).use { pathStream ->
          pathStream.forEach { path ->

--- a/PackrLauncher/src/main/cpp/linux/packr_linux.cpp
+++ b/PackrLauncher/src/main/cpp/linux/packr_linux.cpp
@@ -41,21 +41,21 @@ int main(int argc, char** argv) {
     return 0;
 }
 
-bool loadJNIFunctions(GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
+bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
 
     void* handle;
     struct stat buffer;
 
-    if (handle == NULL && stat("jre/lib/server/libjvm.so", &buffer) == 0) {
-        handle = dlopen("jre/lib/server/libjvm.so", RTLD_LAZY);
+    if (handle == NULL && stat((jrePath + "/lib/server/libjvm.so").c_str(), &buffer) == 0) {
+        handle = dlopen((jrePath + "/lib/server/libjvm.so").c_str(), RTLD_LAZY);
     }
 
-    if (handle == NULL && stat("jre/lib/amd64/server/libjvm.so", &buffer) == 0) {
-        handle = dlopen("jre/lib/amd64/server/libjvm.so", RTLD_LAZY);
+    if (handle == NULL && stat((jrePath + "/lib/amd64/server/libjvm.so").c_str(), &buffer) == 0) {
+        handle = dlopen((jrePath + "/lib/amd64/server/libjvm.so").c_str(), RTLD_LAZY);
     }
 
-    if (handle == NULL && stat("jre/lib/i386/server/libjvm.so", &buffer) == 0) {
-        handle = dlopen("jre/lib/i386/server/libjvm.so", RTLD_LAZY);
+    if (handle == NULL && stat((jrePath + "/lib/i386/server/libjvm.so").c_str(), &buffer) == 0) {
+        handle = dlopen((jrePath + "/lib/i386/server/libjvm.so").c_str(), RTLD_LAZY);
     }
 
     if (handle == NULL) {

--- a/PackrLauncher/src/main/cpp/linux/packr_linux.cpp
+++ b/PackrLauncher/src/main/cpp/linux/packr_linux.cpp
@@ -41,21 +41,22 @@ int main(int argc, char** argv) {
     return 0;
 }
 
-bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
+bool loadJNIFunctions(const dropt_char* jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
 
     void* handle;
     struct stat buffer;
+    std::string jrePathString(jrePath);
 
-    if (handle == NULL && stat((jrePath + "/lib/server/libjvm.so").c_str(), &buffer) == 0) {
-        handle = dlopen((jrePath + "/lib/server/libjvm.so").c_str(), RTLD_LAZY);
+    if (handle == NULL && stat((jrePathString + "/lib/server/libjvm.so").c_str(), &buffer) == 0) {
+        handle = dlopen((jrePathString + "/lib/server/libjvm.so").c_str(), RTLD_LAZY);
     }
 
-    if (handle == NULL && stat((jrePath + "/lib/amd64/server/libjvm.so").c_str(), &buffer) == 0) {
-        handle = dlopen((jrePath + "/lib/amd64/server/libjvm.so").c_str(), RTLD_LAZY);
+    if (handle == NULL && stat((jrePathString + "/lib/amd64/server/libjvm.so").c_str(), &buffer) == 0) {
+        handle = dlopen((jrePathString + "/lib/amd64/server/libjvm.so").c_str(), RTLD_LAZY);
     }
 
-    if (handle == NULL && stat((jrePath + "/lib/i386/server/libjvm.so").c_str(), &buffer) == 0) {
-        handle = dlopen((jrePath + "/lib/i386/server/libjvm.so").c_str(), RTLD_LAZY);
+    if (handle == NULL && stat((jrePathString + "/lib/i386/server/libjvm.so").c_str(), &buffer) == 0) {
+        handle = dlopen((jrePathString + "/lib/i386/server/libjvm.so").c_str(), RTLD_LAZY);
     }
 
     if (handle == NULL) {

--- a/PackrLauncher/src/main/cpp/macos/packr_macos.cpp
+++ b/PackrLauncher/src/main/cpp/macos/packr_macos.cpp
@@ -124,9 +124,9 @@ int searchForLibJli(const char *filename, const struct stat *statptr, int filefl
     return 0;
 }
 
-bool loadJNIFunctions(GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
+bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
     libJliSearchPath[0] = 0;
-    nftw("jre", searchForLibJli, 5, FTW_CHDIR | FTW_DEPTH | FTW_MOUNT);
+    nftw(jrePath.c_str(), searchForLibJli, 5, FTW_CHDIR | FTW_DEPTH | FTW_MOUNT);
 
     string libJliAbsolutePath;
     char currentWorkingDirectoryPath[MAXPATHLEN];

--- a/PackrLauncher/src/main/cpp/macos/packr_macos.cpp
+++ b/PackrLauncher/src/main/cpp/macos/packr_macos.cpp
@@ -124,9 +124,9 @@ int searchForLibJli(const char *filename, const struct stat *statptr, int filefl
     return 0;
 }
 
-bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
+bool loadJNIFunctions(const dropt_char* jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM) {
     libJliSearchPath[0] = 0;
-    nftw(jrePath.c_str(), searchForLibJli, 5, FTW_CHDIR | FTW_DEPTH | FTW_MOUNT);
+    nftw(jrePath, searchForLibJli, 5, FTW_CHDIR | FTW_DEPTH | FTW_MOUNT);
 
     string libJliAbsolutePath;
     char currentWorkingDirectoryPath[MAXPATHLEN];

--- a/PackrLauncher/src/main/cpp/packr.cpp
+++ b/PackrLauncher/src/main/cpp/packr.cpp
@@ -497,7 +497,15 @@ void launchJavaVM(const LaunchJavaVMCallback &callback) {
     GetDefaultJavaVMInitArgs getDefaultJavaVMInitArgs = nullptr;
     CreateJavaVM createJavaVM = nullptr;
 
-    if (!loadJNIFunctions(&getDefaultJavaVMInitArgs, &createJavaVM)) {
+    const string originalJrePath = hasJsonValue(jsonRoot, "jrePath", sajson::TYPE_STRING) ?
+        getJsonValue(jsonRoot, "jrePath").as_string() : "jre";
+    string trimmedJrePath = originalJrePath;
+    // Removes trailing slash.
+    if ('/' == trimmedJrePath.back())
+        trimmedJrePath.pop_back();
+    const string jrePath = trimmedJrePath;
+
+    if (!loadJNIFunctions(jrePath, &getDefaultJavaVMInitArgs, &createJavaVM)) {
         cerr << "Error: failed to load VM runtime library!" << endl;
         exit(EXIT_FAILURE);
     }

--- a/PackrLauncher/src/main/cpp/win32/packr_win32.cpp
+++ b/PackrLauncher/src/main/cpp/win32/packr_win32.cpp
@@ -283,35 +283,19 @@ void loadLibraries(const TCHAR* libraryPattern) {
    FindClose(hFind);
 }
 
-LPCWSTR stringToLpcwstr(const std::string& s) {
-   std::wstring stemp = std::wstring(s.begin(), s.end());
-   LPCWSTR sw = stemp.c_str();
-   return sw;
-}
-
-const TCHAR* stringToTcharPointer(const std::string& s) {
-    const TCHAR* pstring = nullptr;
-    #ifdef UNICODE
-        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-        std::wstring wstr = converter.from_bytes(s);
-        pstring = wstr.data();
-    #else
-        pstring = s.data();
-    #endif
-    return pstring;
-}
-
-bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs *getDefaultJavaVMInitArgs, CreateJavaVM *createJavaVM) {
-   std::string backslashedJrePath = jrePath;
-   std::replace(backslashedJrePath.begin(), backslashedJrePath.end(), '/', '\\');
-   addDllDirectory(stringToLpcwstr(backslashedJrePath + "\\bin"));
-   addDllDirectory(stringToLpcwstr(backslashedJrePath + "\\bin\\server"));
+bool loadJNIFunctions(const dropt_char* jrePath, GetDefaultJavaVMInitArgs *getDefaultJavaVMInitArgs, CreateJavaVM *createJavaVM) {
+   wstring backslashedJrePath = wstring(jrePath);
+   std::replace(backslashedJrePath.begin(), backslashedJrePath.end(), L'/', L'\\');
+   addDllDirectory((backslashedJrePath + L"\\bin").c_str());
+   addDllDirectory((backslashedJrePath + L"\\bin\\server").c_str());
 
    // Load every shared library in jre/bin because awt.dll doesn't load its dependent libraries using the correct search paths
-   loadLibraries(stringToTcharPointer(backslashedJrePath + "\\bin\\*.dll"));
+   wstring allDllsWstring = backslashedJrePath + L"\\bin\\*.dll";
+   const dropt_char* allDlls = allDllsWstring.c_str();
+   loadLibraries(allDlls);
 
    TCHAR jvmDllFullPath[FULL_PATH_SIZE] = TEXT("");
-   if (GetFullPathName(stringToLpcwstr(backslashedJrePath + "\\bin\\server\\jvm.dll"), FULL_PATH_SIZE, jvmDllFullPath, nullptr) == 0) {
+   if (GetFullPathName((backslashedJrePath + L"\\bin\\server\\jvm.dll").c_str(), FULL_PATH_SIZE, jvmDllFullPath, nullptr) == 0) {
       printLastError(TEXT("get the jvm.dll absolute path"));
       return false;
    }

--- a/PackrLauncher/src/main/headers/packr.h
+++ b/PackrLauncher/src/main/headers/packr.h
@@ -41,7 +41,7 @@ extern "C" {
 	extern const char __CLASS_PATH_DELIM;
 
 	/* platform-dependent functions */
-	bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM);
+	bool loadJNIFunctions(const dropt_char* jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM);
 	const dropt_char* getExecutablePath(const dropt_char* argv0);
 
 	bool changeWorkingDir(const dropt_char* directory);

--- a/PackrLauncher/src/main/headers/packr.h
+++ b/PackrLauncher/src/main/headers/packr.h
@@ -41,7 +41,7 @@ extern "C" {
 	extern const char __CLASS_PATH_DELIM;
 
 	/* platform-dependent functions */
-	bool loadJNIFunctions(GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM);
+	bool loadJNIFunctions(const std::string& jrePath, GetDefaultJavaVMInitArgs* getDefaultJavaVMInitArgs, CreateJavaVM* createJavaVM);
 	const dropt_char* getExecutablePath(const dropt_char* argv0);
 
 	bool changeWorkingDir(const dropt_char* directory);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ java -jar packr-all.jar \
 | platform | one of "windows64",  "linux64", "mac" |
 | jdk | Directory, zip file, tar.gz file, or URL to an archive file of a JRE or Java 8 JDK with a JRE folder in it. Adopt OpenJDK 8, 11, and 15 are tested against <https://adoptopenjdk.net/releases.html>. You can also specify a directory to an unpacked JDK distribution. E.g. using ${java.home} in a build script.|
 | executable | name of the native executable, without extension such as ".exe" |
+| jrePath (optional) | path to the bundled JRE. By default, the JRE will be placed in a folder called "jre". |
 | classpath | file locations of the JAR files to package |
 | removelibs (optional) | file locations of JAR files to remove native libraries which do not match the target platform. See below for details. |
 | mainclass | the fully qualified name of the main class, using dots to delimit package names |

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+# Unreleased 3.1.0
+1. Added an option to specify the JRE directory in the configuration file.
 # Released 3.0.3
 1. Fixed symbolic link issue for Linux and macOS JREs.
 1. Fixed pthread not being available on Linux.


### PR DESCRIPTION
This PR implements a new field called jrePath in config.json.
This is my solution to the problem described here: https://github.com/libgdx/packr/issues/191
The main idea is to let the user choose the name of the bundled JRE folder so that a self-updating app can easily switch to a new JRE.
Let me know if this solution is not appropriate and/or if there are better alternatives.

I've also added the --jrePath option to the packaging tool (not the launcher).
The default value is "jre" for backward compatibility.
I've changed the tests to use this new option: "--jrePath jre-123456". The tests are successful on Windows, Linux and Mac.

Anyway this is mostly a proof of concept, I'm trying to get a discussion going about it.

By the way @karlsabo I'm not sure how you build, run the tests and publish launcher natives and packr-all. Are you able to do it in a single step or are there multiple steps involved?
To do it in one single step in my fork I had to make a custom GitHub Actions workflow that 1- publishes the packr launcher native executables to GitHub Packages, and 2- runs the tests.